### PR TITLE
Reset fuel offsets per engine start

### DIFF
--- a/Nasal/Systems/fuel.nas
+++ b/Nasal/Systems/fuel.nas
@@ -69,10 +69,10 @@ var FUEL = {
 		me.resetFailures();
 	},
 	setOffsetLeft: func() {
-		me.Quantity.offsetLeft.setValue(me.Quantity.offsetLeft.getValue() - pts.Fdm.JSBSim.Propulsion.Engine.fuelUsed[0].getValue());
+		me.Quantity.offsetLeft.setValue(-pts.Fdm.JSBSim.Propulsion.Engine.fuelUsed[0].getValue());
 	},
 	setOffsetRight: func() {
-		me.Quantity.offsetRight.setValue(me.Quantity.offsetRight.getValue() - pts.Fdm.JSBSim.Propulsion.Engine.fuelUsed[1].getValue());
+		me.Quantity.offsetRight.setValue(-pts.Fdm.JSBSim.Propulsion.Engine.fuelUsed[1].getValue());
 	}
 };
 


### PR DESCRIPTION
## REMAINS IN LOCAL REPO ONLY
### CAUTION: DON´T RESTORE BRANCH
Local branch is going to be rebased

------

## Summary
- simplify fuel offset handling to set per-engine consumption to zero at each start
- use JSBSim total fuel-used values directly so ECAM consumption resets cleanly per start

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367aff51c4832c92a0ef62dc84a592)