### PR TITLE
Fix pressurization target altitude clamping

### DIFF
--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -183,6 +183,10 @@ var PNEU = {
 		# Legacy pressurization
 		cabinalt = getprop("/systems/pressurization/cabinalt");
 		targetalt = getprop("/systems/pressurization/targetalt");
+		deadbandft = 150;
+		if (!wowl and !wowr and math.abs(targetalt - cabinalt) < deadbandft) {
+			targetalt = cabinalt; # locally clamp to avoid hunting; property remains owned by filters
+		}
 		ambient = getprop("/systems/pressurization/ambientpsi");
 		cabinpsi = getprop("/systems/pressurization/cabinpsi");
 		state1 = systems.FADEC.detentText[0].getValue();

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -314,16 +314,10 @@
 		<update-interval-secs>0.1</update-interval-secs>
 		<input>
 			<condition>
-				<or>
-					<equals>
-						<property>/gear/gear[1]/wow</property>
-						<value>1</value>
-					</equals>
-					<less-than>
-						<property>/systems/pressurization/targetalt-cmd</property>
-						<property>/systems/pressurization/cabinalt-norm</property>
-					</less-than>
-				</or>
+				<equals>
+					<property>/gear/gear[1]/wow</property>
+					<value>1</value>
+				</equals>
 			</condition>
 			<property>/systems/pressurization/cabinalt-norm</property>
 		</input>


### PR DESCRIPTION
Toto je původní větev kde jsem zkoušel úpravy systému tlakování.
Následně jsem s úpravami přešel do:
https://github.com/kchodl/A320-family/pull/6
a pak do ( :D ):
https://github.com/kchodl/A320-family/pull/7

------

## Summary
- fix pressurization target altitude filter so airborne target follows commanded cabin altitude

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694288da2630832c867797800ea8d43f)