### PR TITLE
Remove duplicate Cabin PSI target entry

### DIFF
--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -352,7 +352,6 @@
 					<property>/systems/pressurization/cabinalt-norm</property>
 					<entry><ind>-1000</ind><dep>16.50000</dep></entry>
 					<entry><ind>    0</ind><dep>14.70000</dep></entry>
-					<entry><ind>    0</ind><dep>14.70000</dep></entry>
 					<entry><ind> 1000</ind><dep>14.20000</dep></entry>
 					<entry><ind> 2000</ind><dep>13.60000</dep></entry>
 					<entry><ind> 3000</ind><dep>13.20000</dep></entry>


### PR DESCRIPTION
### Description of Changes
- Remove the duplicate Cabin PSI target table entry so only one 0/14.70000 row remains.

### Screenshots (optional)
- n/a

### Bugs fixed (if any)
- None

### Checklist:
* [ ] My changes follow the Contributing Guidelines.
* [ ] My changes implement realistic features.
* [ ] Please have a main Developer test my changes before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab40531fc832cab5f3b740cde1126)