### PR TITLE
A320 PNEU: write pressurization init values as numbers

### DIFF
--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -932,22 +932,22 @@ var reset_FMGC = func {
 	Input.alt.setValue(alt);
 	
 	systems.PNEU.pressMode.setValue("GN");
-	setprop("/systems/pressurization/vs", "0");
-	setprop("/systems/pressurization/targetvs", "0");
-	setprop("/systems/pressurization/vs-norm", "0");
+	setprop("/systems/pressurization/vs", 0);
+	setprop("/systems/pressurization/targetvs", 0);
+	setprop("/systems/pressurization/vs-norm", 0);
 	setprop("/systems/pressurization/auto", 1);
-	setprop("/systems/pressurization/deltap", "0");
-	setprop("/systems/pressurization/outflowpos", "0");
-	setprop("/systems/pressurization/deltap-norm", "0");
-	setprop("/systems/pressurization/outflowpos-norm", "0");
+	setprop("/systems/pressurization/deltap", 0);
+	setprop("/systems/pressurization/outflowpos", 0);
+	setprop("/systems/pressurization/deltap-norm", 0);
+	setprop("/systems/pressurization/outflowpos-norm", 0);
 	altitude = pts.Instrumentation.Altimeter.indicatedFt.getValue();
 	setprop("/systems/pressurization/cabinalt", altitude);
 	setprop("/systems/pressurization/targetalt", altitude); 
-	setprop("/systems/pressurization/diff-to-target", "0");
+	setprop("/systems/pressurization/diff-to-target", 0);
 	setprop("/systems/pressurization/ditchingpb", 0);
-	setprop("/systems/pressurization/targetvs", "0");
-	setprop("/systems/pressurization/ambientpsi", "0");
-	setprop("/systems/pressurization/cabinpsi", "0");
+	setprop("/systems/pressurization/targetvs", 0);
+	setprop("/systems/pressurization/ambientpsi", 0);
+	setprop("/systems/pressurization/cabinpsi", 0);
 	
 }
 

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -137,25 +137,25 @@ var PNEU = {
 		
 		# Legacy pressurization system
 		setprop("/systems/pressurization/mode", "GN");
-		setprop("/systems/pressurization/vs", "0");
-		setprop("/systems/pressurization/targetvs", "0");
-		setprop("/systems/pressurization/vs-norm", "0");
+		setprop("/systems/pressurization/vs", 0);
+		setprop("/systems/pressurization/targetvs", 0);
+		setprop("/systems/pressurization/vs-norm", 0);
 		setprop("/systems/pressurization/auto", 1);
-		setprop("/systems/pressurization/deltap", "0");
-		setprop("/systems/pressurization/outflowpos", "0");
-		setprop("/systems/pressurization/deltap-norm", "0");
-		setprop("/systems/pressurization/outflowpos-norm", "0");
-		setprop("/systems/pressurization/outflowpos-man", "0.5");
-		setprop("/systems/pressurization/outflowpos-man-sw", "0");
-		setprop("/systems/pressurization/outflowpos-norm-cmd", "0");
+		setprop("/systems/pressurization/deltap", 0);
+		setprop("/systems/pressurization/outflowpos", 0);
+		setprop("/systems/pressurization/deltap-norm", 0);
+		setprop("/systems/pressurization/outflowpos-norm", 0);
+		setprop("/systems/pressurization/outflowpos-man", 0.5);
+		setprop("/systems/pressurization/outflowpos-man-sw", 0);
+		setprop("/systems/pressurization/outflowpos-norm-cmd", 0);
 		setprop("/systems/pressurization/cabinalt", pts.Instrumentation.Altimeter.indicatedFt.getValue());
 		setprop("/systems/pressurization/targetalt", pts.Instrumentation.Altimeter.indicatedFt.getValue()); 
-		setprop("/systems/pressurization/diff-to-target", "0");
+		setprop("/systems/pressurization/diff-to-target", 0);
 		setprop("/systems/pressurization/ditchingpb", 0);
-		setprop("/systems/pressurization/targetvs", "0");
+		setprop("/systems/pressurization/targetvs", 0);
 			setprop("/systems/pressurization/ambientpsi", 14.7);
 			setprop("/systems/pressurization/cabinpsi", 14.7);
-		setprop("/systems/pressurization/manvs-cmd", "0");
+		setprop("/systems/pressurization/manvs-cmd", 0);
 			var init_alt = pts.Instrumentation.Altimeter.indicatedFt.getValue();
 			if (init_alt == nil) init_alt = 0;
 			setprop("/systems/pressurization/landing-elev", init_alt);


### PR DESCRIPTION
### Motivation
- External graphing module (Phy) rejects numeric properties stored as strings, causing incompatibility.
- The legacy pressurization initialization writes numeric values as string literals, which should be numeric properties in the property tree.
- `reset_FMGC()` is invoked from MCDU flows and also rewrites pressurization properties; without fixing this reset path, numeric nodes could revert back to string type during normal operation (breaking Phy graphs again).
- Changes must remain minimal and confined to pressurization `setprop()` literals (**anti-churn**, **no refactors**).

### Description
- **Commit 1 — `Nasal/Systems/pneumatics.nas`:**
  - Replaced numeric string literals with numeric literals in `setprop()` calls for legacy pressurization initialization.
  - Updated properties include:
    - `/systems/pressurization/vs`
    - `/systems/pressurization/targetvs` *(including the duplicate initializer)*
    - `/systems/pressurization/vs-norm`
    - `/systems/pressurization/deltap`
    - `/systems/pressurization/outflowpos`
    - `/systems/pressurization/deltap-norm`
    - `/systems/pressurization/outflowpos-norm`
    - `/systems/pressurization/outflowpos-man` *(now `0.5`)*
    - `/systems/pressurization/outflowpos-man-sw`
    - `/systems/pressurization/outflowpos-norm-cmd`
    - `/systems/pressurization/diff-to-target`
    - `/systems/pressurization/manvs-cmd`
  - Preserved non-numeric string properties (e.g. `setprop("/systems/pressurization/mode", "GN")`), comments, and did not modify any logic.

- **Commit 2 — `Nasal/FMGC/FMGC.nas`:**
  - In `reset_FMGC()`, replaced numeric string literals with numeric literals for pressurization properties to prevent MCDU-triggered resets from restoring string-typed numeric nodes.
  - Updated properties include:
    - `/systems/pressurization/vs`
    - `/systems/pressurization/targetvs` *(including the duplicate occurrence within the reset block)*
    - `/systems/pressurization/vs-norm`
    - `/systems/pressurization/deltap`
    - `/systems/pressurization/outflowpos`
    - `/systems/pressurization/deltap-norm`
    - `/systems/pressurization/outflowpos-norm`
    - `/systems/pressurization/diff-to-target`
    - `/systems/pressurization/ambientpsi`
    - `/systems/pressurization/cabinpsi`
  - No other functional code was changed.

### Testing
- Validation searches:
  - `Nasal/Systems/pneumatics.nas`:
    ```bash
    rg -n --hidden --no-ignore-vcs 'setprop\("/systems/pressurization/[^\"]+"\s*,\s*"[-+]?[0-9]+(\.[0-9]+)?"\s*\)' Nasal/Systems/pneumatics.nas
    ```
    - Expected/Observed: only a match inside a commented line that was intentionally left unchanged.
  - `Nasal/FMGC/FMGC.nas`:
    ```bash
    rg -n --hidden --no-ignore-vcs 'setprop\("/systems/pressurization/[^\"]+"\s*,\s*"[-+]?[0-9]+(\.[0-9]+)?"\s*\)' Nasal/FMGC/FMGC.nas
    ```
    - Expected/Observed: no matches.
- No runtime behavior changes are expected; this is a type-correctness change only (numeric string literals → numeric literals).
