### PR TITLE
Cabin pressurization: robust descent + ground equalization

### DIFF
--- a/Nasal/ECAM/ECAM-logic.nas
+++ b/Nasal/ECAM/ECAM-logic.nas
@@ -1073,7 +1073,7 @@ var messages_priority_3 = func {
 	}
 	
 	# CAB PRESS EXESS RESIDUAL PRESS
-	if (excessResidPress.clearFlag == 0 and warningNodes.Logic.excessPress.getValue() == 1 and phaseVar == 10) {
+		if (phaseVar3 == 10 and excessResidPress.clearFlag == 0 and warningNodes.Logic.excessPress.getValue() == 1) {
 		if (excessResidPressPack1.clearFlag == 0) {
 			excessResidPressPack1.active = 1;
 		} else {

--- a/Nasal/ECAM/ECAM-logic.nas
+++ b/Nasal/ECAM/ECAM-logic.nas
@@ -1073,7 +1073,9 @@ var messages_priority_3 = func {
 	}
 	
 	# CAB PRESS EXESS RESIDUAL PRESS
-		if (phaseVar3 == 10 and excessResidPress.clearFlag == 0 and warningNodes.Logic.excessPress.getValue() == 1) {
+	if (phaseVar3 == 10 and warningNodes.Logic.excessPress.getValue() == 1 and excessResidPress.clearFlag == 0) {
+		excessResidPress.active = 1;
+
 		if (excessResidPressPack1.clearFlag == 0) {
 			excessResidPressPack1.active = 1;
 		} else {

--- a/Nasal/FMGC/FMGC.nas
+++ b/Nasal/FMGC/FMGC.nas
@@ -932,22 +932,22 @@ var reset_FMGC = func {
 	Input.alt.setValue(alt);
 	
 	systems.PNEU.pressMode.setValue("GN");
-	setprop("/systems/pressurization/vs", "0");
-	setprop("/systems/pressurization/targetvs", "0");
-	setprop("/systems/pressurization/vs-norm", "0");
+	setprop("/systems/pressurization/vs", 0);
+	setprop("/systems/pressurization/targetvs", 0);
+	setprop("/systems/pressurization/vs-norm", 0);
 	setprop("/systems/pressurization/auto", 1);
-	setprop("/systems/pressurization/deltap", "0");
-	setprop("/systems/pressurization/outflowpos", "0");
-	setprop("/systems/pressurization/deltap-norm", "0");
-	setprop("/systems/pressurization/outflowpos-norm", "0");
+	setprop("/systems/pressurization/deltap", 0);
+	setprop("/systems/pressurization/outflowpos", 0);
+	setprop("/systems/pressurization/deltap-norm", 0);
+	setprop("/systems/pressurization/outflowpos-norm", 0);
 	altitude = pts.Instrumentation.Altimeter.indicatedFt.getValue();
 	setprop("/systems/pressurization/cabinalt", altitude);
 	setprop("/systems/pressurization/targetalt", altitude); 
-	setprop("/systems/pressurization/diff-to-target", "0");
+	setprop("/systems/pressurization/diff-to-target", 0);
 	setprop("/systems/pressurization/ditchingpb", 0);
-	setprop("/systems/pressurization/targetvs", "0");
-	setprop("/systems/pressurization/ambientpsi", "0");
-	setprop("/systems/pressurization/cabinpsi", "0");
+	setprop("/systems/pressurization/targetvs", 0);
+	setprop("/systems/pressurization/ambientpsi", 0);
+	setprop("/systems/pressurization/cabinpsi", 0);
 	
 }
 

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -196,6 +196,11 @@ var PNEU = {
 		ditch = getprop("/systems/pressurization/ditchingpb");
 		outflowpos = getprop("/systems/pressurization/outflowpos");
 		targetvs = getprop("/systems/pressurization/targetvs");
+		var dt = getprop("/sim/time/delta-sec", 0.1);
+		var step = 0;
+		var newalt = cabinalt;
+		if (dt < 0.01) dt = 0.01;
+		if (dt > 0.2) dt = 0.2;
 		
 		setprop("/systems/pressurization/diff-to-target", targetalt - cabinalt); 
 		setprop("/systems/pressurization/deltap", cabinpsi - ambient); 
@@ -210,10 +215,18 @@ var PNEU = {
 			setprop("/systems/pressurization/vs", targetvs);
 		}
 		
-		if (cabinalt != targetalt and !wowl and !wowr and !pause and auto) {
-			setprop("/systems/pressurization/cabinalt", cabinalt + ((vs / 60) / 10));
+		if (auto and !pause and !wowl and !wowr) {
+			if (math.abs(targetalt - cabinalt) > 0.5) {
+				step = vs * dt / 60;
+				newalt = cabinalt + step;
+				if ((cabinalt < targetalt and newalt > targetalt) or (cabinalt > targetalt and newalt < targetalt)) {
+					newalt = targetalt;
+				}
+				setprop("/systems/pressurization/cabinalt", newalt);
+			}
 		} else if (!auto and !pause) {
-			setprop("/systems/pressurization/cabinalt", cabinalt + ((manvs / 60) / 10));
+			step = manvs * dt / 60;
+			setprop("/systems/pressurization/cabinalt", cabinalt + step);
 		}
 		
 		#if (ditch and auto) {

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -143,8 +143,8 @@ var PNEU = {
 		setprop("/systems/pressurization/diff-to-target", "0");
 		setprop("/systems/pressurization/ditchingpb", 0);
 		setprop("/systems/pressurization/targetvs", "0");
-		setprop("/systems/pressurization/ambientpsi", "0");
-		setprop("/systems/pressurization/cabinpsi", "0");
+			setprop("/systems/pressurization/ambientpsi", 14.7);
+			setprop("/systems/pressurization/cabinpsi", 14.7);
 		setprop("/systems/pressurization/manvs-cmd", "0");
 			var init_alt = pts.Instrumentation.Altimeter.indicatedFt.getValue();
 			if (init_alt == nil) init_alt = 0;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -23,7 +23,7 @@ var eng1_starter = nil;
 var eng2_starter = nil;
 var VS_MAX = 750;
 var last_press_elapsed = nil;
-var press_avail_latched = 1;
+var press_avail_latched = 0;
 var press_avail_drop_s = 0;
 
 # Main class
@@ -243,7 +243,7 @@ var PNEU = {
 		if (door_l1 > 0.001 or door_l4 > 0.001 or door_r1 > 0.001 or door_r4 > 0.001) doors_open = 1;
 		setprop("/systems/pressurization/doors-open", doors_open);
 		var pack_factor = getprop("/systems/air-conditioning/packs/pack-factor");
-		if (pack_factor == nil) pack_factor = 1;
+		if (pack_factor == nil) pack_factor = 0;
 		if (press_avail_drop_s == nil) press_avail_drop_s = 0;
 		var press_avail_inst = 0;
 		if (pack_factor != 0) press_avail_inst = 1;
@@ -253,6 +253,9 @@ var PNEU = {
 		} else if (!on_ground) {
 			press_avail_drop_s += dt;
 			if (press_avail_drop_s >= 1.0) press_avail_latched = 0;
+		} else {
+			press_avail_latched = 0;
+			press_avail_drop_s = 0;
 		}
 		setprop("/systems/pressurization/press-avail", press_avail_latched);
 		var eq_mode = 0;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -200,6 +200,7 @@ var PNEU = {
 		if (manvs == nil) manvs = 0;
 		pause = getprop("/sim/freeze/master");
 		auto = getprop("/systems/pressurization/auto");
+		if (auto == nil) auto = 1;
 		speed = getprop("/velocities/groundspeed-kt");
 		if (speed == nil) speed = 0;
 		ditch = getprop("/systems/pressurization/ditchingpb");
@@ -219,6 +220,7 @@ var PNEU = {
 		if (dt == nil) dt = 0.1;
 		var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft");
 		if (aircraft_alt == nil) aircraft_alt = cabinalt;
+		if (aircraft_alt == nil) aircraft_alt = 0;
 		var aircraft_vs = getprop("/velocities/vertical-speed-fps");
 		if (aircraft_vs == nil) aircraft_vs = 0;
 		aircraft_vs *= 60; # fpm

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -23,6 +23,8 @@ var eng1_starter = nil;
 var eng2_starter = nil;
 var VS_MAX = 750;
 var last_press_elapsed = nil;
+var press_avail_latched = 1;
+var press_avail_drop_s = 0;
 
 # Main class
 var PNEU = {
@@ -242,9 +244,17 @@ var PNEU = {
 		setprop("/systems/pressurization/doors-open", doors_open);
 		var pack_factor = getprop("/systems/air-conditioning/packs/pack-factor");
 		if (pack_factor == nil) pack_factor = 1;
-		var press_avail = 0;
-		if (pack_factor != 0) press_avail = 1;
-		setprop("/systems/pressurization/press-avail", press_avail);
+		if (press_avail_drop_s == nil) press_avail_drop_s = 0;
+		var press_avail_inst = 0;
+		if (pack_factor != 0) press_avail_inst = 1;
+		if (press_avail_inst == 1) {
+			press_avail_latched = 1;
+			press_avail_drop_s = 0;
+		} else if (!on_ground) {
+			press_avail_drop_s += dt;
+			if (press_avail_drop_s >= 1.0) press_avail_latched = 0;
+		}
+		setprop("/systems/pressurization/press-avail", press_avail_latched);
 		var eq_mode = 0;
 		if (on_ground and !pause) eq_mode = 1;
 		setprop("/systems/pressurization/eq-mode", eq_mode);
@@ -314,7 +324,7 @@ var PNEU = {
 		
 		var diff = targetalt - cabinalt;
 		var commanded_vs = targetvs; # default to schedule
-		var active = (!pause) and ((press_avail == 1) or on_ground);
+		var active = (!pause) and ((press_avail_latched == 1) or on_ground);
 		if (auto and active) {
 			var alt_above_ldg = alt_ind - landing_elev;
 			if (alt_above_ldg < 0) alt_above_ldg = 0;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -226,9 +226,11 @@ var PNEU = {
 		}
 		if (targetalt == nil) targetalt = cabinalt;
 		
-		setprop("/systems/pressurization/diff-to-target", targetalt - cabinalt); 
-		setprop("/systems/pressurization/diff-to-targetalt", targetalt - cabinalt); 
-		setprop("/systems/pressurization/deltap", cabinpsi - ambient); 
+			var targetalt_cmd = getprop("/systems/pressurization/targetalt-cmd");
+			if (targetalt_cmd == nil) targetalt_cmd = targetalt;
+			setprop("/systems/pressurization/diff-to-target", targetalt - cabinalt); 
+			setprop("/systems/pressurization/diff-to-targetalt", targetalt_cmd - cabinalt); 
+			setprop("/systems/pressurization/deltap", cabinpsi - ambient); 
 	
 		if ((pressmode == "GN") and (pressmode != "CL") and (wowl and wowr) and ((state1 == "MCT") or (state1 == "TOGA")) and ((state2 == "MCT") or (state2 == "TOGA"))) {
 			setprop("/systems/pressurization/mode", "TO");
@@ -285,15 +287,17 @@ var PNEU = {
 					var vs_int = getprop("/systems/pressurization/vs-norm");
 					if (vs_int == nil) vs_int = vs_cmd;
 					step = vs_int * dt / 60;
-				newalt = cabinalt + step;
-				if ((cabinalt < targetalt and newalt > targetalt) or (cabinalt > targetalt and newalt < targetalt)) {
-					newalt = targetalt;
-				}
+					newalt = cabinalt + step;
+					if ((cabinalt < targetalt and newalt > targetalt) or (cabinalt > targetalt and newalt < targetalt)) {
+						newalt = targetalt;
+					}
 					if (newalt > aircraft_alt) newalt = aircraft_alt; # avoid negative delta-P near landing
 					setprop("/systems/pressurization/cabinalt", newalt);
 				}
 			} else if (!auto and !pause) {
-				step = manvs * dt / 60;
+				var vs_int_man = getprop("/systems/pressurization/vs-norm");
+				if (vs_int_man == nil) vs_int_man = vs_cmd;
+				step = vs_int_man * dt / 60;
 				newalt = cabinalt + step;
 				if (newalt > aircraft_alt) newalt = aircraft_alt; # avoid negative delta-P near landing
 				setprop("/systems/pressurization/cabinalt", newalt);

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -223,6 +223,19 @@ var PNEU = {
 		if (alt_ind == nil) alt_ind = 0;
 		var alt_press = getprop("/instrumentation/altimeter/pressure-alt-ft");
 		if (alt_press == nil) alt_press = alt_ind;
+		var gps_alt = getprop("/instrumentation/gps/indicated-altitude-ft");
+		var ground_elev = getprop("/position/ground-elev-ft");
+		var alt_ground = alt_ind;
+		if (gps_alt != nil and gps_alt > -1500 and gps_alt < 20000) {
+			var use_gps = 1;
+			if (ground_elev != nil) {
+				use_gps = 0;
+				if (math.abs(gps_alt - ground_elev) <= 300) {
+					use_gps = 1;
+				}
+			}
+			if (use_gps == 1) alt_ground = gps_alt;
+		}
 		var aircraft_vs = getprop("/velocities/vertical-speed-fps");
 		if (aircraft_vs == nil) aircraft_vs = 0;
 		aircraft_vs *= 60; # fpm
@@ -251,8 +264,8 @@ var PNEU = {
 			cabinalt = alt_ind;
 			setprop("/systems/pressurization/cabinalt", cabinalt);
 		}
-		if (on_ground and (cabinalt == nil or math.abs(cabinalt - alt_ind) > 50)) {
-			cabinalt = alt_ind;
+		if (on_ground and (cabinalt == nil or math.abs(cabinalt - alt_ground) > 50)) {
+			cabinalt = alt_ground;
 			setprop("/systems/pressurization/cabinalt", cabinalt);
 		}
 		if (targetalt == nil) targetalt = cabinalt;
@@ -272,7 +285,7 @@ var PNEU = {
 		# latch landing elevation: on ground track current altitude, in air prefer FMGC value if sane
 		var ldg_prop = getprop("/FMGC/internal/ldg-elev");
 		if (on_ground) {
-			landing_elev = alt_ind;
+			landing_elev = alt_ground;
 			setprop("/systems/pressurization/landing-elev", landing_elev);
 		} else if (ldg_prop != nil and ldg_prop != 0 and ldg_prop > -1500 and ldg_prop < 20000) {
 			landing_elev = ldg_prop;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -25,6 +25,8 @@ var VS_MAX = 750;
 var last_press_elapsed = nil;
 var press_avail_latched = 0;
 var press_avail_drop_s = 0;
+var cabinalt_bootstrap_done = 0;
+var cabinalt_bootstrap_t0 = nil;
 
 # Main class
 var PNEU = {
@@ -219,6 +221,7 @@ var PNEU = {
 			}
 			last_press_elapsed = now;
 		}
+		if (cabinalt_bootstrap_t0 == nil and now != nil) cabinalt_bootstrap_t0 = now;
 		if (dt == nil) dt = 0.1;
 		var alt_ind = getprop("/instrumentation/altimeter/indicated-altitude-ft");
 		if (alt_ind == nil) alt_ind = cabinalt;
@@ -262,6 +265,30 @@ var PNEU = {
 		if (on_ground and !pause) eq_mode = 1;
 		setprop("/systems/pressurization/eq-mode", eq_mode);
 		setprop("/systems/pressurization/eq-targetalt", eq_targetalt);
+		if (cabinalt_bootstrap_done == 0 and on_ground and !pause and now != nil and cabinalt_bootstrap_t0 != nil and (now - cabinalt_bootstrap_t0) <= 30) {
+			var ref = eq_targetalt;
+			var pos_alt = getprop("/position/altitude-ft");
+			if (ref == nil or math.abs(ref) <= 1) ref = ground_elev;
+			if (ref == nil or math.abs(ref) <= 1) ref = pos_alt;
+			if (ref == nil) ref = 0;
+			var sensors_ready = 0;
+			if ((ground_elev != nil and math.abs(ground_elev) > 1) or (eq_targetalt != nil and math.abs(eq_targetalt) > 1) or (pos_alt != nil and math.abs(pos_alt) > 1)) {
+				sensors_ready = 1;
+			}
+			var cab = cabinalt;
+			if (cab == nil) cab = 0;
+			var cab_uninit = (cab < 50);
+			var cab_far = (cab < 200 and math.abs(ref - cab) > 500);
+			var ref_ok = (ref > -1000 and ref < 20000);
+			if (ref_ok and sensors_ready and (cab_uninit or cab_far)) {
+				cabinalt = ref;
+				targetalt = ref;
+				setprop("/systems/pressurization/cabinalt", cabinalt);
+				setprop("/systems/pressurization/targetalt", targetalt);
+				cabinalt_bootstrap_done = 1;
+			}
+		}
+		setprop("/systems/pressurization/cabinalt-bootstrap-done", cabinalt_bootstrap_done);
 		if (gps_alt != nil and gps_alt > -1500 and gps_alt < 20000) {
 			var use_gps = 1;
 			if (ground_elev != nil) {

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -204,19 +204,31 @@ var PNEU = {
 		
 		setprop("/systems/pressurization/diff-to-target", targetalt - cabinalt); 
 		setprop("/systems/pressurization/deltap", cabinpsi - ambient); 
-
+	
 		if ((pressmode == "GN") and (pressmode != "CL") and (wowl and wowr) and ((state1 == "MCT") or (state1 == "TOGA")) and ((state2 == "MCT") or (state2 == "TOGA"))) {
 			setprop("/systems/pressurization/mode", "TO");
 		} else if (((!wowl) or (!wowr)) and (speed > 100) and (pressmode == "TO")) {
 			setprop("/systems/pressurization/mode", "CL");	
 		}
 		
-		if (vs != targetvs and !wowl and !wowr) {
-			setprop("/systems/pressurization/vs", targetvs);
+		var diff = targetalt - cabinalt;
+		var commanded_vs = targetvs;
+		if (auto and !pause and !wowl and !wowr and math.abs(diff) > 200) {
+			var catchup_rate = math.abs(diff) / 6;
+			if (catchup_rate < 300) catchup_rate = 300;
+			if (catchup_rate > 750) catchup_rate = 750;
+			commanded_vs = math.sign(diff) * math.max(math.abs(targetvs), catchup_rate);
+		} else if (!auto and !pause) {
+			commanded_vs = manvs;
+		}
+		
+		if (commanded_vs != vs and !wowl and !wowr) {
+			setprop("/systems/pressurization/vs", commanded_vs);
+			vs = commanded_vs;
 		}
 		
 		if (auto and !pause and !wowl and !wowr) {
-			if (math.abs(targetalt - cabinalt) > 0.5) {
+			if (math.abs(diff) > 0.5) {
 				step = vs * dt / 60;
 				newalt = cabinalt + step;
 				if ((cabinalt < targetalt and newalt > targetalt) or (cabinalt > targetalt and newalt < targetalt)) {

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -201,8 +201,8 @@ var PNEU = {
 		auto = getprop("/systems/pressurization/auto");
 		speed = getprop("/velocities/groundspeed-kt");
 		if (speed == nil) speed = 0;
-		ditch = getprop("/systems/pressurization/ditchingpb");
-		outflowpos = getprop("/systems/pressurization/outflowpos");
+			ditch = getprop("/systems/pressurization/ditchingpb");
+			outflowpos = getprop("/systems/pressurization/outflowpos");
 			targetvs = getprop("/systems/pressurization/targetvs");
 			if (targetvs == nil) targetvs = 0;
 			vs_cmd = getprop("/systems/pressurization/vs");

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -325,7 +325,16 @@ var PNEU = {
 		var diff = targetalt - cabinalt;
 		var commanded_vs = targetvs; # default to schedule
 		var active = (!pause) and ((press_avail_latched == 1) or on_ground);
-		if (auto and active) {
+		if (eq_mode == 1 and active) {
+			var TAU_MIN = 0.5; # minutes
+			var VS_EQ_MAX = 250; # fpm clamp for equalization
+			var commanded_vs_eq = diff / TAU_MIN;
+			if (commanded_vs_eq > VS_EQ_MAX) commanded_vs_eq = VS_EQ_MAX;
+			if (commanded_vs_eq < -VS_EQ_MAX) commanded_vs_eq = -VS_EQ_MAX;
+			commanded_vs = commanded_vs_eq;
+			if (commanded_vs > VS_MAX) commanded_vs = VS_MAX;
+			if (commanded_vs < -VS_MAX) commanded_vs = -VS_MAX;
+		} else if (auto and active) {
 			var alt_above_ldg = alt_ind - landing_elev;
 			if (alt_above_ldg < 0) alt_above_ldg = 0;
 			var vs_floor = 750; # fpm for time metric

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -203,8 +203,8 @@ var PNEU = {
 		if (speed == nil) speed = 0;
 		ditch = getprop("/systems/pressurization/ditchingpb");
 		outflowpos = getprop("/systems/pressurization/outflowpos");
-		targetvs = getprop("/systems/pressurization/targetvs");
-		if (targetvs == nil) targetvs = 0;
+			targetvs = getprop("/systems/pressurization/targetvs");
+			if (targetvs == nil) targetvs = 0;
 			vs_cmd = getprop("/systems/pressurization/vs");
 			if (vs_cmd == nil) vs_cmd = targetvs;
 			var now = getprop("/sim/time/elapsed-sec");

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -25,8 +25,13 @@ var VS_MAX = 750;
 var last_press_elapsed = nil;
 var press_avail_latched = 0;
 var press_avail_drop_s = 0;
-var cabinalt_bootstrap_done = 0;
-var cabinalt_bootstrap_t0 = nil;
+var boot_t0 = nil;
+var boot_done = 0;
+var boot_expired = 0;
+var boot_prev_altp = nil;
+var boot_stable_s = 0;
+var boot_seen_valid_altp = 0;
+var boot_fire_elapsed = 0;
 
 # Main class
 var PNEU = {
@@ -221,7 +226,6 @@ var PNEU = {
 			}
 			last_press_elapsed = now;
 		}
-		if (cabinalt_bootstrap_t0 == nil and now != nil) cabinalt_bootstrap_t0 = now;
 		if (dt == nil) dt = 0.1;
 		var alt_ind = getprop("/instrumentation/altimeter/indicated-altitude-ft");
 		if (alt_ind == nil) alt_ind = cabinalt;
@@ -265,30 +269,48 @@ var PNEU = {
 		if (on_ground and !pause) eq_mode = 1;
 		setprop("/systems/pressurization/eq-mode", eq_mode);
 		setprop("/systems/pressurization/eq-targetalt", eq_targetalt);
-		if (cabinalt_bootstrap_done == 0 and on_ground and !pause and now != nil and cabinalt_bootstrap_t0 != nil and (now - cabinalt_bootstrap_t0) <= 30) {
-			var ref = eq_targetalt;
-			var pos_alt = getprop("/position/altitude-ft");
-			if (ref == nil or math.abs(ref) <= 1) ref = ground_elev;
-			if (ref == nil or math.abs(ref) <= 1) ref = pos_alt;
-			if (ref == nil) ref = 0;
-			var sensors_ready = 0;
-			if ((ground_elev != nil and math.abs(ground_elev) > 1) or (eq_targetalt != nil and math.abs(eq_targetalt) > 1) or (pos_alt != nil and math.abs(pos_alt) > 1)) {
-				sensors_ready = 1;
-			}
-			var cab = cabinalt;
-			if (cab == nil) cab = 0;
-			var cab_uninit = (cab < 50);
-			var cab_far = (cab < 200 and math.abs(ref - cab) > 500);
-			var ref_ok = (ref > -1000 and ref < 20000);
-			if (ref_ok and sensors_ready and (cab_uninit or cab_far)) {
-				cabinalt = ref;
-				targetalt = ref;
-				setprop("/systems/pressurization/cabinalt", cabinalt);
-				setprop("/systems/pressurization/targetalt", targetalt);
-				cabinalt_bootstrap_done = 1;
+		if (boot_t0 == nil and now != nil) boot_t0 = now;
+		if (boot_done == 0 and boot_expired == 0 and on_ground and !pause) {
+			if (boot_t0 != nil and now != nil and (now - boot_t0) > 30) boot_expired = 1;
+			if (boot_expired == 0) {
+				var altp = getprop("/instrumentation/altimeter/pressure-alt-ft");
+				if (altp == nil) {
+					boot_stable_s = 0;
+				} else {
+					if (math.abs(altp) > 1 and math.abs(altp) < 60000) boot_seen_valid_altp = 1;
+					if (boot_seen_valid_altp == 1) {
+						if (boot_prev_altp != nil and math.abs(altp - boot_prev_altp) < 2) {
+							boot_stable_s += dt;
+						} else {
+							boot_stable_s = 0;
+						}
+					}
+					boot_prev_altp = altp;
+				}
+				var gs = getprop("/velocities/groundspeed-kt");
+				if (gs == nil) gs = 0;
+				if (boot_seen_valid_altp == 1 and boot_stable_s >= 1.0 and gs < 5) {
+					var ref = eq_targetalt;
+					if (ref == nil) ref = altp;
+					if (ref == nil) ref = getprop("/position/altitude-ft");
+					if (ref == nil) ref = 0;
+					var cab = cabinalt;
+					if (cab == nil) cab = ref;
+					if ((cab < 50) or (math.abs(ref - cab) > 20)) {
+						cabinalt = ref;
+						targetalt = ref;
+						setprop("/systems/pressurization/cabinalt", cabinalt);
+						setprop("/systems/pressurization/targetalt", targetalt);
+						boot_done = 1;
+						if (now != nil) boot_fire_elapsed = now;
+					}
+				}
 			}
 		}
-		setprop("/systems/pressurization/cabinalt-bootstrap-done", cabinalt_bootstrap_done);
+		setprop("/systems/pressurization/cabinalt-bootstrap-done", boot_done);
+		setprop("/systems/pressurization/cabinalt-bootstrap-fire-elapsed", boot_fire_elapsed);
+		setprop("/systems/pressurization/cabinalt-bootstrap-stable-s", boot_stable_s);
+		setprop("/systems/pressurization/cabinalt-bootstrap-expired", boot_expired);
 		if (gps_alt != nil and gps_alt > -1500 and gps_alt < 20000) {
 			var use_gps = 1;
 			if (ground_elev != nil) {

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -226,6 +226,22 @@ var PNEU = {
 		var gps_alt = getprop("/instrumentation/gps/indicated-altitude-ft");
 		var ground_elev = getprop("/position/ground-elev-ft");
 		var alt_ground = alt_ind;
+		var door_l1 = getprop("/sim/model/door-positions/doorl1/position-norm");
+		if (door_l1 == nil) door_l1 = 0;
+		var door_l4 = getprop("/sim/model/door-positions/doorl4/position-norm");
+		if (door_l4 == nil) door_l4 = 0;
+		var door_r1 = getprop("/sim/model/door-positions/doorr1/position-norm");
+		if (door_r1 == nil) door_r1 = 0;
+		var door_r4 = getprop("/sim/model/door-positions/doorr4/position-norm");
+		if (door_r4 == nil) door_r4 = 0;
+		var doors_open = 0;
+		if (door_l1 > 0.001 or door_l4 > 0.001 or door_r1 > 0.001 or door_r4 > 0.001) doors_open = 1;
+		setprop("/systems/pressurization/doors-open", doors_open);
+		var pack_factor = getprop("/systems/air-conditioning/packs/pack-factor");
+		if (pack_factor == nil) pack_factor = 1;
+		var press_avail = 0;
+		if (pack_factor != 0) press_avail = 1;
+		setprop("/systems/pressurization/press-avail", press_avail);
 		if (gps_alt != nil and gps_alt > -1500 and gps_alt < 20000) {
 			var use_gps = 1;
 			if (ground_elev != nil) {
@@ -261,11 +277,7 @@ var PNEU = {
 		setprop("/systems/pressurization/ambientpsi", ambient);
 		if (cabinpsi == nil) cabinpsi = ambient;
 		if (cabinalt == nil) {
-			cabinalt = alt_ind;
-			setprop("/systems/pressurization/cabinalt", cabinalt);
-		}
-		if (on_ground and (cabinalt == nil or math.abs(cabinalt - alt_ground) > 50)) {
-			cabinalt = alt_ground;
+			cabinalt = alt_press;
 			setprop("/systems/pressurization/cabinalt", cabinalt);
 		}
 		if (targetalt == nil) targetalt = cabinalt;
@@ -294,7 +306,8 @@ var PNEU = {
 		
 		var diff = targetalt - cabinalt;
 		var commanded_vs = targetvs; # default to schedule
-		if (auto and !pause and !wowl and !wowr) {
+		var active = (press_avail == 1) and (!pause);
+		if (auto and active) {
 			var alt_above_ldg = alt_ind - landing_elev;
 			if (alt_above_ldg < 0) alt_above_ldg = 0;
 			var vs_floor = 750; # fpm for time metric
@@ -315,18 +328,19 @@ var PNEU = {
 			commanded_vs = targetvs + catchup_rate;
 			if (commanded_vs > VS_MAX) commanded_vs = VS_MAX;
 			if (commanded_vs < -VS_MAX) commanded_vs = -VS_MAX;
-		} else if (!auto and !pause) {
+		} else if (!auto and active) {
 			commanded_vs = manvs;
 			if (commanded_vs > VS_MAX) commanded_vs = VS_MAX;
 			if (commanded_vs < -VS_MAX) commanded_vs = -VS_MAX;
 		}
 
-		if (commanded_vs != vs_cmd and !wowl and !wowr) {
+		if (!active) commanded_vs = 0;
+		if (commanded_vs != vs_cmd) {
 			setprop("/systems/pressurization/vs", commanded_vs);
 			vs_cmd = commanded_vs;
 		}
 		
-		if (auto and !pause and !wowl and !wowr) {
+		if (auto and active) {
 			if (math.abs(diff) > 0.5) {
 				var vs_int = getprop("/systems/pressurization/vs-norm");
 				if (vs_int == nil) vs_int = vs_cmd;
@@ -338,7 +352,7 @@ var PNEU = {
 					if (newalt > alt_press) newalt = alt_press; # avoid negative delta-P near landing
 					setprop("/systems/pressurization/cabinalt", newalt);
 				}
-			} else if (!auto and !pause) {
+			} else if (!auto and active) {
 				var vs_int_man = getprop("/systems/pressurization/vs-norm");
 				if (vs_int_man == nil) vs_int_man = vs_cmd;
 				step = vs_int_man * dt / 60;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -21,6 +21,8 @@ var outflowpos = nil;
 var targetvs = nil; 
 var eng1_starter = nil;
 var eng2_starter = nil;
+var VS_MAX = 750;
+var last_press_elapsed = nil;
 
 # Main class
 var PNEU = {
@@ -205,27 +207,42 @@ var PNEU = {
 		if (targetvs == nil) targetvs = 0;
 		vs_cmd = getprop("/systems/pressurization/vs");
 		if (vs_cmd == nil) vs_cmd = targetvs;
+		var now = getprop("/sim/time/elapsed-sec");
 		var dt = getprop("/sim/time/delta-sec");
+		if (now != nil) {
+			if (!pause and last_press_elapsed != nil and now > last_press_elapsed) {
+				dt = now - last_press_elapsed;
+			}
+			if (pause) {
+				last_press_elapsed = now;
+			} else {
+				last_press_elapsed = now;
+			}
+		}
 		if (dt == nil) dt = 0.1;
-			var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft");
-			if (aircraft_alt == nil) aircraft_alt = cabinalt;
-			var aircraft_vs = getprop("/velocities/vertical-speed-fps");
-			if (aircraft_vs == nil) aircraft_vs = 0;
+		var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft");
+		if (aircraft_alt == nil) aircraft_alt = cabinalt;
+		var aircraft_vs = getprop("/velocities/vertical-speed-fps");
+		if (aircraft_vs == nil) aircraft_vs = 0;
 			aircraft_vs *= 60; # fpm
 			var landing_elev = getprop("/systems/pressurization/landing-elev");
 			if (landing_elev == nil) landing_elev = aircraft_alt;
-		var step = 0;
-		var newalt = cabinalt;
-		if (dt < 0.01) dt = 0.01;
-		if (dt > 0.2) dt = 0.2;
+			var step = 0;
+			var newalt = cabinalt;
+		if (pause) {
+			dt = 0;
+		} else {
+			if (dt < 0.01) dt = 0.01;
+			if (dt > 0.2) dt = 0.2;
+		}
 		if (ambient == nil) ambient = 0;
 		if (cabinpsi == nil) cabinpsi = ambient;
-		if (cabinalt == nil) {
-			cabinalt = aircraft_alt;
-			setprop("/systems/pressurization/cabinalt", cabinalt);
-		}
-		if (targetalt == nil) targetalt = cabinalt;
-		
+			if (cabinalt == nil) {
+				cabinalt = aircraft_alt;
+				setprop("/systems/pressurization/cabinalt", cabinalt);
+			}
+			if (targetalt == nil) targetalt = cabinalt;
+			
 			var targetalt_cmd = getprop("/systems/pressurization/targetalt-cmd");
 			if (targetalt_cmd == nil) targetalt_cmd = targetalt;
 			setprop("/systems/pressurization/diff-to-target", targetalt - cabinalt); 
@@ -250,32 +267,32 @@ var PNEU = {
 		
 		var diff = targetalt - cabinalt;
 		var commanded_vs = targetvs; # default to schedule
-		if (auto and !pause and !wowl and !wowr) {
-			var alt_above_ldg = aircraft_alt - landing_elev;
-			if (alt_above_ldg < 0) alt_above_ldg = 0;
-			var vs_floor = 750; # fpm for time metric
-			var vs_for_time = math.max(math.abs(aircraft_vs), vs_floor);
-			var t_go = alt_above_ldg / vs_for_time; # minutes (ft / fpm)
-			var VsMax = 1500; # fpm clamp
-			var t_need = math.abs(diff) / VsMax;
-			var t_min = math.max(dt / 60, 0.02); # minutes
-			t_go = math.max(t_go, t_min);
-			t_need = math.max(t_need, t_min);
-			var t_eff = math.sqrt(t_go * t_need);
+			if (auto and !pause and !wowl and !wowr) {
+				var alt_above_ldg = aircraft_alt - landing_elev;
+				if (alt_above_ldg < 0) alt_above_ldg = 0;
+				var vs_floor = 750; # fpm for time metric
+				var vs_for_time = math.max(math.abs(aircraft_vs), vs_floor);
+				var t_go = alt_above_ldg / vs_for_time; # minutes (ft / fpm)
+				var VsMax = VS_MAX; # fpm clamp
+				var t_need = math.abs(diff) / VsMax;
+				var t_min = math.max(dt / 60, 0.02); # minutes
+				t_go = math.max(t_go, t_min);
+				t_need = math.max(t_need, t_min);
+				var t_eff = math.sqrt(t_go * t_need);
 			var catchup_rate = 0;
 			if (math.abs(diff) > 25) {
 				catchup_rate = diff / t_eff;
 				if (catchup_rate > VsMax) catchup_rate = VsMax;
 				if (catchup_rate < -VsMax) catchup_rate = -VsMax;
+				}
+				commanded_vs = targetvs + catchup_rate;
+				if (commanded_vs > VS_MAX) commanded_vs = VS_MAX;
+				if (commanded_vs < -VS_MAX) commanded_vs = -VS_MAX;
+			} else if (!auto and !pause) {
+				commanded_vs = manvs;
+				if (commanded_vs > VS_MAX) commanded_vs = VS_MAX;
+				if (commanded_vs < -VS_MAX) commanded_vs = -VS_MAX;
 			}
-			commanded_vs = targetvs + catchup_rate;
-			if (commanded_vs > 1500) commanded_vs = 1500;
-			if (commanded_vs < -1500) commanded_vs = -1500;
-		} else if (!auto and !pause) {
-			commanded_vs = manvs;
-			if (commanded_vs > 1500) commanded_vs = 1500;
-			if (commanded_vs < -1500) commanded_vs = -1500;
-		}
 		
 		if (commanded_vs != vs_cmd and !wowl and !wowr) {
 			setprop("/systems/pressurization/vs", commanded_vs);

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -144,7 +144,9 @@ var PNEU = {
 		setprop("/systems/pressurization/ambientpsi", "0");
 		setprop("/systems/pressurization/cabinpsi", "0");
 		setprop("/systems/pressurization/manvs-cmd", "0");
-		setprop("/systems/pressurization/landing-elev", 0);
+			var init_alt = pts.Instrumentation.Altimeter.indicatedFt.getValue();
+			if (init_alt == nil) init_alt = 0;
+			setprop("/systems/pressurization/landing-elev", init_alt);
 		setprop("/systems/pressurization/pack-1-out-temp", 0);
 		setprop("/systems/pressurization/pack-2-out-temp", 0);
 		setprop("/systems/pressurization/pack-1-bypass", 0);
@@ -189,30 +191,40 @@ var PNEU = {
 		state1 = systems.FADEC.detentText[0].getValue();
 		state2 = systems.FADEC.detentText[1].getValue();
 		pressmode = getprop("/systems/pressurization/mode");
-		vs = getprop("/systems/pressurization/vs-norm");
-		if (vs == nil) vs = 0;
+		vs_norm = getprop("/systems/pressurization/vs-norm");
+		if (vs_norm == nil) vs_norm = 0;
 		manvs = getprop("/systems/pressurization/manvs-cmd");
 		if (manvs == nil) manvs = 0;
 		pause = getprop("/sim/freeze/master");
 		auto = getprop("/systems/pressurization/auto");
-		speed = getprop("velocities/groundspeed-kt");
+		speed = getprop("/velocities/groundspeed-kt");
+		if (speed == nil) speed = 0;
 		ditch = getprop("/systems/pressurization/ditchingpb");
 		outflowpos = getprop("/systems/pressurization/outflowpos");
 		targetvs = getprop("/systems/pressurization/targetvs");
 		if (targetvs == nil) targetvs = 0;
+		vs_cmd = getprop("/systems/pressurization/vs");
+		if (vs_cmd == nil) vs_cmd = targetvs;
 		var dt = getprop("/sim/time/delta-sec");
 		if (dt == nil) dt = 0.1;
-		var landing_elev = getprop("/systems/pressurization/landing-elev");
-		if (landing_elev == nil) landing_elev = 0;
 		var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft");
 		if (aircraft_alt == nil) aircraft_alt = cabinalt;
 		var aircraft_vs = getprop("/velocities/vertical-speed-fps");
 		if (aircraft_vs == nil) aircraft_vs = 0;
 		aircraft_vs *= 60; # fpm
+		var landing_elev = getprop("/systems/pressurization/landing-elev");
+		if (landing_elev == nil) landing_elev = aircraft_alt;
 		var step = 0;
 		var newalt = cabinalt;
 		if (dt < 0.01) dt = 0.01;
 		if (dt > 0.2) dt = 0.2;
+		if (ambient == nil) ambient = 0;
+		if (cabinpsi == nil) cabinpsi = ambient;
+		if (cabinalt == nil) {
+			cabinalt = aircraft_alt;
+			setprop("/systems/pressurization/cabinalt", cabinalt);
+		}
+		if (targetalt == nil) targetalt = cabinalt;
 		
 		setprop("/systems/pressurization/diff-to-target", targetalt - cabinalt); 
 		setprop("/systems/pressurization/deltap", cabinpsi - ambient); 
@@ -226,6 +238,16 @@ var PNEU = {
 		var diff = targetalt - cabinalt;
 		var commanded_vs = targetvs; # default to schedule
 		if (auto and !pause and !wowl and !wowr) {
+			# latch landing elevation: on ground track current altitude, in air prefer FMGC value if sane
+			var ldg_prop = getprop("/FMGC/internal/ldg-elev");
+			if (wowl and wowr) {
+				landing_elev = aircraft_alt;
+				setprop("/systems/pressurization/landing-elev", landing_elev);
+			} else if (ldg_prop != nil and ldg_prop > -1500 and ldg_prop < 20000) {
+				landing_elev = ldg_prop;
+				setprop("/systems/pressurization/landing-elev", landing_elev);
+			}
+			
 			var alt_above_ldg = aircraft_alt - landing_elev;
 			if (alt_above_ldg < 0) alt_above_ldg = 0;
 			var vs_for_time = math.max(math.abs(aircraft_vs), 50); # avoid divide-by-zero
@@ -239,18 +261,21 @@ var PNEU = {
 			commanded_vs = manvs;
 		}
 		
-		if (commanded_vs != vs and !wowl and !wowr) {
+		if (commanded_vs != vs_cmd and !wowl and !wowr) {
 			setprop("/systems/pressurization/vs", commanded_vs);
-			vs = commanded_vs;
+			vs_cmd = commanded_vs;
 		}
 		
 		if (auto and !pause and !wowl and !wowr) {
 			if (math.abs(diff) > 0.5) {
-				step = vs * dt / 60;
+				var vs_int = getprop("/systems/pressurization/vs-norm");
+				if (vs_int == nil) vs_int = vs_cmd;
+				step = vs_int * dt / 60;
 				newalt = cabinalt + step;
 				if ((cabinalt < targetalt and newalt > targetalt) or (cabinalt > targetalt and newalt < targetalt)) {
 					newalt = targetalt;
 				}
+				if (newalt > aircraft_alt) newalt = aircraft_alt; # avoid negative delta-P near landing
 				setprop("/systems/pressurization/cabinalt", newalt);
 			}
 		} else if (!auto and !pause) {

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -189,17 +189,25 @@ var PNEU = {
 		state2 = systems.FADEC.detentText[1].getValue();
 		pressmode = getprop("/systems/pressurization/mode");
 		vs = getprop("/systems/pressurization/vs-norm");
+		if (vs == nil) vs = 0;
 		manvs = getprop("/systems/pressurization/manvs-cmd");
+		if (manvs == nil) manvs = 0;
 		pause = getprop("/sim/freeze/master");
 		auto = getprop("/systems/pressurization/auto");
 		speed = getprop("velocities/groundspeed-kt");
 		ditch = getprop("/systems/pressurization/ditchingpb");
 		outflowpos = getprop("/systems/pressurization/outflowpos");
 		targetvs = getprop("/systems/pressurization/targetvs");
-		var dt = getprop("/sim/time/delta-sec", 0.1);
-		var landing_elev = getprop("/systems/pressurization/landing-elev", 0);
-		var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft", cabinalt);
-		var aircraft_vs = getprop("/velocities/vertical-speed-fps", 0) * 60; # fpm
+		if (targetvs == nil) targetvs = 0;
+		var dt = getprop("/sim/time/delta-sec");
+		if (dt == nil) dt = 0.1;
+		var landing_elev = getprop("/systems/pressurization/landing-elev");
+		if (landing_elev == nil) landing_elev = 0;
+		var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft");
+		if (aircraft_alt == nil) aircraft_alt = cabinalt;
+		var aircraft_vs = getprop("/velocities/vertical-speed-fps");
+		if (aircraft_vs == nil) aircraft_vs = 0;
+		aircraft_vs *= 60; # fpm
 		var step = 0;
 		var newalt = cabinalt;
 		if (dt < 0.01) dt = 0.01;
@@ -220,10 +228,7 @@ var PNEU = {
 			var alt_above_ldg = aircraft_alt - landing_elev;
 			if (alt_above_ldg < 0) alt_above_ldg = 0;
 			var vs_for_time = math.max(math.abs(aircraft_vs), 50); # avoid divide-by-zero
-			var time_to_ldg = 0;
-			if (vs_for_time > 0) {
-				time_to_ldg = alt_above_ldg / vs_for_time; # minutes cancel to give minutes? alt(ft)/fpm = minutes
-			}
+			var time_to_ldg = alt_above_ldg / vs_for_time; # minutes? (ft / fpm)
 			if (time_to_ldg < 0.01) time_to_ldg = 0.01; # protect
 			var catchup_rate = diff / time_to_ldg; # ft/min target to close by landing
 			if (catchup_rate > 1500) catchup_rate = 1500;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -205,20 +205,16 @@ var PNEU = {
 		outflowpos = getprop("/systems/pressurization/outflowpos");
 		targetvs = getprop("/systems/pressurization/targetvs");
 		if (targetvs == nil) targetvs = 0;
-		vs_cmd = getprop("/systems/pressurization/vs");
-		if (vs_cmd == nil) vs_cmd = targetvs;
-		var now = getprop("/sim/time/elapsed-sec");
-		var dt = getprop("/sim/time/delta-sec");
-		if (now != nil) {
-			if (!pause and last_press_elapsed != nil and now > last_press_elapsed) {
-				dt = now - last_press_elapsed;
-			}
-			if (pause) {
-				last_press_elapsed = now;
-			} else {
+			vs_cmd = getprop("/systems/pressurization/vs");
+			if (vs_cmd == nil) vs_cmd = targetvs;
+			var now = getprop("/sim/time/elapsed-sec");
+			var dt = getprop("/sim/time/delta-sec");
+			if (now != nil) {
+				if (!pause and last_press_elapsed != nil and now > last_press_elapsed) {
+					dt = now - last_press_elapsed;
+				}
 				last_press_elapsed = now;
 			}
-		}
 		if (dt == nil) dt = 0.1;
 		var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft");
 		if (aircraft_alt == nil) aircraft_alt = cabinalt;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -212,11 +212,11 @@ var PNEU = {
 		}
 		
 		var diff = targetalt - cabinalt;
-		var commanded_vs = targetvs;
+		var commanded_vs = targetvs; # default to schedule
 		if (auto and !pause and !wowl and !wowr and math.abs(diff) > 200) {
-			var catchup_rate = math.abs(diff) / 6;
-			if (catchup_rate < 300) catchup_rate = 300;
-			if (catchup_rate > 750) catchup_rate = 750;
+			var catchup_rate = math.abs(diff) / 4; # ft/min
+			if (catchup_rate < 400) catchup_rate = 400;
+			if (catchup_rate > 1000) catchup_rate = 1000;
 			commanded_vs = math.sign(diff) * math.max(math.abs(targetvs), catchup_rate);
 		} else if (!auto and !pause) {
 			commanded_vs = manvs;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -197,6 +197,9 @@ var PNEU = {
 		outflowpos = getprop("/systems/pressurization/outflowpos");
 		targetvs = getprop("/systems/pressurization/targetvs");
 		var dt = getprop("/sim/time/delta-sec", 0.1);
+		var landing_elev = getprop("/systems/pressurization/landing-elev", 0);
+		var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft", cabinalt);
+		var aircraft_vs = getprop("/velocities/vertical-speed-fps", 0) * 60; # fpm
 		var step = 0;
 		var newalt = cabinalt;
 		if (dt < 0.01) dt = 0.01;
@@ -213,11 +216,19 @@ var PNEU = {
 		
 		var diff = targetalt - cabinalt;
 		var commanded_vs = targetvs; # default to schedule
-		if (auto and !pause and !wowl and !wowr and math.abs(diff) > 200) {
-			var catchup_rate = math.abs(diff) / 4; # ft/min
-			if (catchup_rate < 400) catchup_rate = 400;
-			if (catchup_rate > 1000) catchup_rate = 1000;
-			commanded_vs = math.sign(diff) * math.max(math.abs(targetvs), catchup_rate);
+		if (auto and !pause and !wowl and !wowr) {
+			var alt_above_ldg = aircraft_alt - landing_elev;
+			if (alt_above_ldg < 0) alt_above_ldg = 0;
+			var vs_for_time = math.max(math.abs(aircraft_vs), 50); # avoid divide-by-zero
+			var time_to_ldg = 0;
+			if (vs_for_time > 0) {
+				time_to_ldg = alt_above_ldg / vs_for_time; # minutes cancel to give minutes? alt(ft)/fpm = minutes
+			}
+			if (time_to_ldg < 0.01) time_to_ldg = 0.01; # protect
+			var catchup_rate = diff / time_to_ldg; # ft/min target to close by landing
+			if (catchup_rate > 1500) catchup_rate = 1500;
+			if (catchup_rate < -1500) catchup_rate = -1500;
+			commanded_vs = targetvs + catchup_rate;
 		} else if (!auto and !pause) {
 			commanded_vs = manvs;
 		}

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -218,14 +218,16 @@ var PNEU = {
 			last_press_elapsed = now;
 		}
 		if (dt == nil) dt = 0.1;
-		var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft");
-		if (aircraft_alt == nil) aircraft_alt = cabinalt;
-		if (aircraft_alt == nil) aircraft_alt = 0;
+		var alt_ind = getprop("/instrumentation/altimeter/indicated-altitude-ft");
+		if (alt_ind == nil) alt_ind = cabinalt;
+		if (alt_ind == nil) alt_ind = 0;
+		var alt_press = getprop("/instrumentation/altimeter/pressure-alt-ft");
+		if (alt_press == nil) alt_press = alt_ind;
 		var aircraft_vs = getprop("/velocities/vertical-speed-fps");
 		if (aircraft_vs == nil) aircraft_vs = 0;
 		aircraft_vs *= 60; # fpm
 		var landing_elev = getprop("/systems/pressurization/landing-elev");
-		if (landing_elev == nil) landing_elev = aircraft_alt;
+		if (landing_elev == nil) landing_elev = alt_ind;
 		var step = 0;
 		var newalt = cabinalt;
 		if (pause) {
@@ -235,14 +237,22 @@ var PNEU = {
 			if (dt > 0.3) dt = 0.3;
 		}
 		setprop("/systems/pressurization/dt-used", dt);
-		if (ambient == nil) ambient = 0;
+		var ambient_prev = ambient;
+		if (ambient_prev == nil) ambient_prev = 14.7;
+		var p_static = getprop("/systems/static[0]/pressure-inhg");
+		if (p_static == nil) p_static = getprop("/environment/pressure-inhg");
+		var ambient_calc = nil;
+		if (p_static != nil) ambient_calc = p_static * 0.491154;
+		ambient = ambient_calc;
+		if (ambient == nil) ambient = ambient_prev;
+		setprop("/systems/pressurization/ambientpsi", ambient);
 		if (cabinpsi == nil) cabinpsi = ambient;
 		if (cabinalt == nil) {
-			cabinalt = aircraft_alt;
+			cabinalt = alt_ind;
 			setprop("/systems/pressurization/cabinalt", cabinalt);
 		}
-		if (on_ground and (cabinalt == nil or math.abs(cabinalt - aircraft_alt) > 50)) {
-			cabinalt = aircraft_alt;
+		if (on_ground and (cabinalt == nil or math.abs(cabinalt - alt_ind) > 50)) {
+			cabinalt = alt_ind;
 			setprop("/systems/pressurization/cabinalt", cabinalt);
 		}
 		if (targetalt == nil) targetalt = cabinalt;
@@ -262,7 +272,7 @@ var PNEU = {
 		# latch landing elevation: on ground track current altitude, in air prefer FMGC value if sane
 		var ldg_prop = getprop("/FMGC/internal/ldg-elev");
 		if (on_ground) {
-			landing_elev = aircraft_alt;
+			landing_elev = alt_ind;
 			setprop("/systems/pressurization/landing-elev", landing_elev);
 		} else if (ldg_prop != nil and ldg_prop != 0 and ldg_prop > -1500 and ldg_prop < 20000) {
 			landing_elev = ldg_prop;
@@ -272,7 +282,7 @@ var PNEU = {
 		var diff = targetalt - cabinalt;
 		var commanded_vs = targetvs; # default to schedule
 		if (auto and !pause and !wowl and !wowr) {
-			var alt_above_ldg = aircraft_alt - landing_elev;
+			var alt_above_ldg = alt_ind - landing_elev;
 			if (alt_above_ldg < 0) alt_above_ldg = 0;
 			var vs_floor = 750; # fpm for time metric
 			var vs_for_time = math.max(math.abs(aircraft_vs), vs_floor);
@@ -307,22 +317,22 @@ var PNEU = {
 			if (math.abs(diff) > 0.5) {
 				var vs_int = getprop("/systems/pressurization/vs-norm");
 				if (vs_int == nil) vs_int = vs_cmd;
-				step = vs_int * dt / 60;
-				newalt = cabinalt + step;
-				if ((cabinalt < targetalt and newalt > targetalt) or (cabinalt > targetalt and newalt < targetalt)) {
-					newalt = targetalt;
+					step = vs_int * dt / 60;
+					newalt = cabinalt + step;
+					if ((cabinalt < targetalt and newalt > targetalt) or (cabinalt > targetalt and newalt < targetalt)) {
+						newalt = targetalt;
+					}
+					if (newalt > alt_press) newalt = alt_press; # avoid negative delta-P near landing
+					setprop("/systems/pressurization/cabinalt", newalt);
 				}
-				if (newalt > aircraft_alt) newalt = aircraft_alt; # avoid negative delta-P near landing
+			} else if (!auto and !pause) {
+				var vs_int_man = getprop("/systems/pressurization/vs-norm");
+				if (vs_int_man == nil) vs_int_man = vs_cmd;
+				step = vs_int_man * dt / 60;
+				newalt = cabinalt + step;
+				if (newalt > alt_press) newalt = alt_press; # avoid negative delta-P near landing
 				setprop("/systems/pressurization/cabinalt", newalt);
 			}
-		} else if (!auto and !pause) {
-			var vs_int_man = getprop("/systems/pressurization/vs-norm");
-			if (vs_int_man == nil) vs_int_man = vs_cmd;
-			step = vs_int_man * dt / 60;
-			newalt = cabinalt + step;
-			if (newalt > aircraft_alt) newalt = aircraft_alt; # avoid negative delta-P near landing
-			setprop("/systems/pressurization/cabinalt", newalt);
-		}
 		
 		#if (ditch and auto) {
 			#setprop("/systems/pressurization/outflowpos", "1");

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -137,25 +137,25 @@ var PNEU = {
 		
 		# Legacy pressurization system
 		setprop("/systems/pressurization/mode", "GN");
-		setprop("/systems/pressurization/vs", "0");
-		setprop("/systems/pressurization/targetvs", "0");
-		setprop("/systems/pressurization/vs-norm", "0");
+		setprop("/systems/pressurization/vs", 0);
+		setprop("/systems/pressurization/targetvs", 0);
+		setprop("/systems/pressurization/vs-norm", 0);
 		setprop("/systems/pressurization/auto", 1);
-		setprop("/systems/pressurization/deltap", "0");
-		setprop("/systems/pressurization/outflowpos", "0");
-		setprop("/systems/pressurization/deltap-norm", "0");
-		setprop("/systems/pressurization/outflowpos-norm", "0");
-		setprop("/systems/pressurization/outflowpos-man", "0.5");
-		setprop("/systems/pressurization/outflowpos-man-sw", "0");
-		setprop("/systems/pressurization/outflowpos-norm-cmd", "0");
+		setprop("/systems/pressurization/deltap", 0);
+		setprop("/systems/pressurization/outflowpos", 0);
+		setprop("/systems/pressurization/deltap-norm", 0);
+		setprop("/systems/pressurization/outflowpos-norm", 0);
+		setprop("/systems/pressurization/outflowpos-man", 0.5);
+		setprop("/systems/pressurization/outflowpos-man-sw", 0);
+		setprop("/systems/pressurization/outflowpos-norm-cmd", 0);
 		setprop("/systems/pressurization/cabinalt", pts.Instrumentation.Altimeter.indicatedFt.getValue());
 		setprop("/systems/pressurization/targetalt", pts.Instrumentation.Altimeter.indicatedFt.getValue()); 
-		setprop("/systems/pressurization/diff-to-target", "0");
+		setprop("/systems/pressurization/diff-to-target", 0);
 		setprop("/systems/pressurization/ditchingpb", 0);
-		setprop("/systems/pressurization/targetvs", "0");
+		setprop("/systems/pressurization/targetvs", 0);
 			setprop("/systems/pressurization/ambientpsi", 14.7);
 			setprop("/systems/pressurization/cabinpsi", 14.7);
-		setprop("/systems/pressurization/manvs-cmd", "0");
+		setprop("/systems/pressurization/manvs-cmd", 0);
 			var init_alt = pts.Instrumentation.Altimeter.indicatedFt.getValue();
 			if (init_alt == nil) init_alt = 0;
 			setprop("/systems/pressurization/landing-elev", init_alt);

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -226,6 +226,9 @@ var PNEU = {
 		var gps_alt = getprop("/instrumentation/gps/indicated-altitude-ft");
 		var ground_elev = getprop("/position/ground-elev-ft");
 		var alt_ground = alt_ind;
+		var eq_targetalt = alt_press;
+		if (eq_targetalt == nil) eq_targetalt = alt_ind;
+		if (eq_targetalt == nil) eq_targetalt = 0;
 		var door_l1 = getprop("/sim/model/door-positions/doorl1/position-norm");
 		if (door_l1 == nil) door_l1 = 0;
 		var door_l4 = getprop("/sim/model/door-positions/doorl4/position-norm");
@@ -242,6 +245,10 @@ var PNEU = {
 		var press_avail = 0;
 		if (pack_factor != 0) press_avail = 1;
 		setprop("/systems/pressurization/press-avail", press_avail);
+		var eq_mode = 0;
+		if (on_ground and !pause) eq_mode = 1;
+		setprop("/systems/pressurization/eq-mode", eq_mode);
+		setprop("/systems/pressurization/eq-targetalt", eq_targetalt);
 		if (gps_alt != nil and gps_alt > -1500 and gps_alt < 20000) {
 			var use_gps = 1;
 			if (ground_elev != nil) {
@@ -306,7 +313,7 @@ var PNEU = {
 		
 		var diff = targetalt - cabinalt;
 		var commanded_vs = targetvs; # default to schedule
-		var active = (press_avail == 1) and (!pause);
+		var active = (!pause) and ((press_avail == 1) or on_ground);
 		if (auto and active) {
 			var alt_above_ldg = alt_ind - landing_elev;
 			if (alt_above_ldg < 0) alt_above_ldg = 0;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -32,6 +32,7 @@ var boot_prev_altp = nil;
 var boot_stable_s = 0;
 var boot_seen_valid_altp = 0;
 var boot_fire_elapsed = 0;
+var boot_anchor_altp = nil;
 
 # Main class
 var PNEU = {
@@ -273,23 +274,31 @@ var PNEU = {
 		if (boot_done == 0 and boot_expired == 0 and on_ground and !pause) {
 			if (boot_t0 != nil and now != nil and (now - boot_t0) > 30) boot_expired = 1;
 			if (boot_expired == 0) {
+				var dt_boot = dt;
+				if (dt_boot == nil) dt_boot = 0.1;
+				if (dt_boot < 0.01) dt_boot = 0.01;
+				if (dt_boot > 0.3) dt_boot = 0.3;
 				var altp = getprop("/instrumentation/altimeter/pressure-alt-ft");
 				if (altp == nil) {
 					boot_stable_s = 0;
+					boot_anchor_altp = nil;
 				} else {
 					if (math.abs(altp) > 1 and math.abs(altp) < 60000) boot_seen_valid_altp = 1;
 					if (boot_seen_valid_altp == 1) {
-						if (boot_prev_altp != nil and math.abs(altp - boot_prev_altp) < 2) {
-							boot_stable_s += dt;
+						if (boot_anchor_altp == nil) boot_anchor_altp = altp;
+						if (boot_prev_altp != nil and math.abs(altp - boot_prev_altp) < 2 and math.abs(altp - boot_anchor_altp) < 5) {
+							boot_stable_s += dt_boot;
 						} else {
 							boot_stable_s = 0;
+							boot_anchor_altp = altp;
 						}
 					}
 					boot_prev_altp = altp;
 				}
 				var gs = getprop("/velocities/groundspeed-kt");
 				if (gs == nil) gs = 0;
-				if (boot_seen_valid_altp == 1 and boot_stable_s >= 1.0 and gs < 5) {
+				# require 2 seconds of stable pressure altitude to avoid transient snap during sensor spin-up
+				if (boot_seen_valid_altp == 1 and boot_stable_s >= 2.0 and gs < 5) {
 					var ref = eq_targetalt;
 					if (ref == nil) ref = altp;
 					if (ref == nil) ref = getprop("/position/altitude-ft");

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -184,6 +184,7 @@ var PNEU = {
 	loop: func(notification) {
 		wowl = notification.gear1Wow;
 		wowr = notification.gear2Wow;
+		var on_ground = (wowl or wowr);
 		
 		# Legacy pressurization
 		cabinalt = getprop("/systems/pressurization/cabinalt");
@@ -201,49 +202,54 @@ var PNEU = {
 		auto = getprop("/systems/pressurization/auto");
 		speed = getprop("/velocities/groundspeed-kt");
 		if (speed == nil) speed = 0;
-			ditch = getprop("/systems/pressurization/ditchingpb");
-			outflowpos = getprop("/systems/pressurization/outflowpos");
-			targetvs = getprop("/systems/pressurization/targetvs");
-			if (targetvs == nil) targetvs = 0;
-			vs_cmd = getprop("/systems/pressurization/vs");
-			if (vs_cmd == nil) vs_cmd = targetvs;
-			var now = getprop("/sim/time/elapsed-sec");
-			var dt = getprop("/sim/time/delta-sec");
-			if (now != nil) {
-				if (!pause and last_press_elapsed != nil and now > last_press_elapsed) {
-					dt = now - last_press_elapsed;
-				}
-				last_press_elapsed = now;
+		ditch = getprop("/systems/pressurization/ditchingpb");
+		outflowpos = getprop("/systems/pressurization/outflowpos");
+		targetvs = getprop("/systems/pressurization/targetvs");
+		if (targetvs == nil) targetvs = 0;
+		vs_cmd = getprop("/systems/pressurization/vs");
+		if (vs_cmd == nil) vs_cmd = targetvs;
+		var now = getprop("/sim/time/elapsed-sec");
+		var dt = getprop("/sim/time/delta-sec");
+		if (now != nil) {
+			if (!pause and last_press_elapsed != nil and now > last_press_elapsed) {
+				dt = now - last_press_elapsed;
 			}
+			last_press_elapsed = now;
+		}
 		if (dt == nil) dt = 0.1;
 		var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft");
 		if (aircraft_alt == nil) aircraft_alt = cabinalt;
 		var aircraft_vs = getprop("/velocities/vertical-speed-fps");
 		if (aircraft_vs == nil) aircraft_vs = 0;
-			aircraft_vs *= 60; # fpm
-			var landing_elev = getprop("/systems/pressurization/landing-elev");
-			if (landing_elev == nil) landing_elev = aircraft_alt;
-			var step = 0;
-			var newalt = cabinalt;
+		aircraft_vs *= 60; # fpm
+		var landing_elev = getprop("/systems/pressurization/landing-elev");
+		if (landing_elev == nil) landing_elev = aircraft_alt;
+		var step = 0;
+		var newalt = cabinalt;
 		if (pause) {
 			dt = 0;
 		} else {
 			if (dt < 0.01) dt = 0.01;
-			if (dt > 0.2) dt = 0.2;
+			if (dt > 0.3) dt = 0.3;
 		}
+		setprop("/systems/pressurization/dt-used", dt);
 		if (ambient == nil) ambient = 0;
 		if (cabinpsi == nil) cabinpsi = ambient;
-			if (cabinalt == nil) {
-				cabinalt = aircraft_alt;
-				setprop("/systems/pressurization/cabinalt", cabinalt);
-			}
-			if (targetalt == nil) targetalt = cabinalt;
-			
-			var targetalt_cmd = getprop("/systems/pressurization/targetalt-cmd");
-			if (targetalt_cmd == nil) targetalt_cmd = targetalt;
-			setprop("/systems/pressurization/diff-to-target", targetalt - cabinalt); 
-			setprop("/systems/pressurization/diff-to-targetalt", targetalt_cmd - cabinalt); 
-			setprop("/systems/pressurization/deltap", cabinpsi - ambient); 
+		if (cabinalt == nil) {
+			cabinalt = aircraft_alt;
+			setprop("/systems/pressurization/cabinalt", cabinalt);
+		}
+		if (on_ground and (cabinalt == nil or math.abs(cabinalt - aircraft_alt) > 50)) {
+			cabinalt = aircraft_alt;
+			setprop("/systems/pressurization/cabinalt", cabinalt);
+		}
+		if (targetalt == nil) targetalt = cabinalt;
+		
+		var targetalt_cmd = getprop("/systems/pressurization/targetalt-cmd");
+		if (targetalt_cmd == nil) targetalt_cmd = targetalt;
+		setprop("/systems/pressurization/diff-to-target", targetalt - cabinalt); 
+		setprop("/systems/pressurization/diff-to-targetalt", targetalt_cmd - cabinalt); 
+		setprop("/systems/pressurization/deltap", cabinpsi - ambient); 
 	
 		if ((pressmode == "GN") and (pressmode != "CL") and (wowl and wowr) and ((state1 == "MCT") or (state1 == "TOGA")) and ((state2 == "MCT") or (state2 == "TOGA"))) {
 			setprop("/systems/pressurization/mode", "TO");
@@ -253,68 +259,68 @@ var PNEU = {
 		
 		# latch landing elevation: on ground track current altitude, in air prefer FMGC value if sane
 		var ldg_prop = getprop("/FMGC/internal/ldg-elev");
-		if (wowl and wowr) {
+		if (on_ground) {
 			landing_elev = aircraft_alt;
 			setprop("/systems/pressurization/landing-elev", landing_elev);
-		} else if (ldg_prop != nil and ldg_prop > -1500 and ldg_prop < 20000) {
+		} else if (ldg_prop != nil and ldg_prop != 0 and ldg_prop > -1500 and ldg_prop < 20000) {
 			landing_elev = ldg_prop;
 			setprop("/systems/pressurization/landing-elev", landing_elev);
 		}
 		
 		var diff = targetalt - cabinalt;
 		var commanded_vs = targetvs; # default to schedule
-			if (auto and !pause and !wowl and !wowr) {
-				var alt_above_ldg = aircraft_alt - landing_elev;
-				if (alt_above_ldg < 0) alt_above_ldg = 0;
-				var vs_floor = 750; # fpm for time metric
-				var vs_for_time = math.max(math.abs(aircraft_vs), vs_floor);
-				var t_go = alt_above_ldg / vs_for_time; # minutes (ft / fpm)
-				var VsMax = VS_MAX; # fpm clamp
-				var t_need = math.abs(diff) / VsMax;
-				var t_min = math.max(dt / 60, 0.02); # minutes
-				t_go = math.max(t_go, t_min);
-				t_need = math.max(t_need, t_min);
-				var t_eff = math.sqrt(t_go * t_need);
+		if (auto and !pause and !wowl and !wowr) {
+			var alt_above_ldg = aircraft_alt - landing_elev;
+			if (alt_above_ldg < 0) alt_above_ldg = 0;
+			var vs_floor = 750; # fpm for time metric
+			var vs_for_time = math.max(math.abs(aircraft_vs), vs_floor);
+			var t_go = alt_above_ldg / vs_for_time; # minutes (ft / fpm)
+			var VsMax = VS_MAX; # fpm clamp
+			var t_need = math.abs(diff) / VsMax;
+			var t_min = math.max(dt / 60, 0.02); # minutes
+			t_go = math.max(t_go, t_min);
+			t_need = math.max(t_need, t_min);
+			var t_eff = math.sqrt(t_go * t_need);
 			var catchup_rate = 0;
 			if (math.abs(diff) > 25) {
 				catchup_rate = diff / t_eff;
 				if (catchup_rate > VsMax) catchup_rate = VsMax;
 				if (catchup_rate < -VsMax) catchup_rate = -VsMax;
-				}
-				commanded_vs = targetvs + catchup_rate;
-				if (commanded_vs > VS_MAX) commanded_vs = VS_MAX;
-				if (commanded_vs < -VS_MAX) commanded_vs = -VS_MAX;
-			} else if (!auto and !pause) {
-				commanded_vs = manvs;
-				if (commanded_vs > VS_MAX) commanded_vs = VS_MAX;
-				if (commanded_vs < -VS_MAX) commanded_vs = -VS_MAX;
 			}
-		
+			commanded_vs = targetvs + catchup_rate;
+			if (commanded_vs > VS_MAX) commanded_vs = VS_MAX;
+			if (commanded_vs < -VS_MAX) commanded_vs = -VS_MAX;
+		} else if (!auto and !pause) {
+			commanded_vs = manvs;
+			if (commanded_vs > VS_MAX) commanded_vs = VS_MAX;
+			if (commanded_vs < -VS_MAX) commanded_vs = -VS_MAX;
+		}
+
 		if (commanded_vs != vs_cmd and !wowl and !wowr) {
 			setprop("/systems/pressurization/vs", commanded_vs);
 			vs_cmd = commanded_vs;
 		}
 		
-			if (auto and !pause and !wowl and !wowr) {
-				if (math.abs(diff) > 0.5) {
-					var vs_int = getprop("/systems/pressurization/vs-norm");
-					if (vs_int == nil) vs_int = vs_cmd;
-					step = vs_int * dt / 60;
-					newalt = cabinalt + step;
-					if ((cabinalt < targetalt and newalt > targetalt) or (cabinalt > targetalt and newalt < targetalt)) {
-						newalt = targetalt;
-					}
-					if (newalt > aircraft_alt) newalt = aircraft_alt; # avoid negative delta-P near landing
-					setprop("/systems/pressurization/cabinalt", newalt);
-				}
-			} else if (!auto and !pause) {
-				var vs_int_man = getprop("/systems/pressurization/vs-norm");
-				if (vs_int_man == nil) vs_int_man = vs_cmd;
-				step = vs_int_man * dt / 60;
+		if (auto and !pause and !wowl and !wowr) {
+			if (math.abs(diff) > 0.5) {
+				var vs_int = getprop("/systems/pressurization/vs-norm");
+				if (vs_int == nil) vs_int = vs_cmd;
+				step = vs_int * dt / 60;
 				newalt = cabinalt + step;
+				if ((cabinalt < targetalt and newalt > targetalt) or (cabinalt > targetalt and newalt < targetalt)) {
+					newalt = targetalt;
+				}
 				if (newalt > aircraft_alt) newalt = aircraft_alt; # avoid negative delta-P near landing
 				setprop("/systems/pressurization/cabinalt", newalt);
 			}
+		} else if (!auto and !pause) {
+			var vs_int_man = getprop("/systems/pressurization/vs-norm");
+			if (vs_int_man == nil) vs_int_man = vs_cmd;
+			step = vs_int_man * dt / 60;
+			newalt = cabinalt + step;
+			if (newalt > aircraft_alt) newalt = aircraft_alt; # avoid negative delta-P near landing
+			setprop("/systems/pressurization/cabinalt", newalt);
+		}
 		
 		#if (ditch and auto) {
 			#setprop("/systems/pressurization/outflowpos", "1");

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -144,6 +144,7 @@ var PNEU = {
 		setprop("/systems/pressurization/ambientpsi", "0");
 		setprop("/systems/pressurization/cabinpsi", "0");
 		setprop("/systems/pressurization/manvs-cmd", "0");
+		setprop("/systems/pressurization/landing-elev", 0);
 		setprop("/systems/pressurization/pack-1-out-temp", 0);
 		setprop("/systems/pressurization/pack-2-out-temp", 0);
 		setprop("/systems/pressurization/pack-1-bypass", 0);

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -346,14 +346,9 @@ var PNEU = {
 		setprop("/systems/pressurization/dt-used", dt);
 		var ambient_prev = ambient;
 		if (ambient_prev == nil) ambient_prev = 14.7;
-		var p_static = getprop("/systems/static[0]/pressure-inhg");
-		if (p_static == nil) p_static = getprop("/environment/pressure-inhg");
-		var ambient_calc = nil;
-		if (p_static != nil) ambient_calc = p_static * 0.491154;
-		ambient = ambient_calc;
+		ambient = getprop("/systems/pressurization/ambientpsi");  # supplied by libraries.xml ISA table
 		if (ambient == nil) ambient = ambient_prev;
 		if (ambient == nil) ambient = 14.7;
-		setprop("/systems/pressurization/ambientpsi", ambient);
 		if (cabinpsi == nil) cabinpsi = ambient;
 		if (cabinalt == nil) {
 			cabinalt = alt_press;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -304,17 +304,23 @@ var PNEU = {
 					if (ref == nil) ref = getprop("/position/altitude-ft");
 					if (ref == nil) ref = 0;
 					var cab = cabinalt;
-					if (cab == nil) cab = ref;
-					if ((cab < 50) or (math.abs(ref - cab) > 20)) {
-						cabinalt = ref;
-						targetalt = ref;
-						setprop("/systems/pressurization/cabinalt", cabinalt);
-						setprop("/systems/pressurization/targetalt", targetalt);
-						boot_done = 1;
-						if (now != nil) boot_fire_elapsed = now;
+						if (cab == nil) cab = ref;
+						if ((cab < 50) or (math.abs(ref - cab) > 20)) {
+							cabinalt = ref;
+							targetalt = ref;
+							setprop("/systems/pressurization/cabinalt", cabinalt);
+							setprop("/systems/pressurization/targetalt", targetalt);
+							var CABIN_ALT_MAX = 40500;
+							var ref_norm = ref;
+							if (ref_norm == nil) ref_norm = 0;
+							if (ref_norm < 0) ref_norm = 0;
+							if (ref_norm > CABIN_ALT_MAX) ref_norm = CABIN_ALT_MAX;
+							setprop("/systems/pressurization/cabinalt-norm", ref_norm);
+							boot_done = 1;
+							if (now != nil) boot_fire_elapsed = now;
+						}
 					}
 				}
-			}
 		}
 		setprop("/systems/pressurization/cabinalt-bootstrap-done", boot_done);
 		setprop("/systems/pressurization/cabinalt-bootstrap-fire-elapsed", boot_fire_elapsed);

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -267,8 +267,12 @@ var PNEU = {
 				if (catchup_rate < -VsMax) catchup_rate = -VsMax;
 			}
 			commanded_vs = targetvs + catchup_rate;
+			if (commanded_vs > 1500) commanded_vs = 1500;
+			if (commanded_vs < -1500) commanded_vs = -1500;
 		} else if (!auto and !pause) {
 			commanded_vs = manvs;
+			if (commanded_vs > 1500) commanded_vs = 1500;
+			if (commanded_vs < -1500) commanded_vs = -1500;
 		}
 		
 		if (commanded_vs != vs_cmd and !wowl and !wowr) {
@@ -276,22 +280,24 @@ var PNEU = {
 			vs_cmd = commanded_vs;
 		}
 		
-		if (auto and !pause and !wowl and !wowr) {
-			if (math.abs(diff) > 0.5) {
-				var vs_int = getprop("/systems/pressurization/vs-norm");
-				if (vs_int == nil) vs_int = vs_cmd;
-				step = vs_int * dt / 60;
+			if (auto and !pause and !wowl and !wowr) {
+				if (math.abs(diff) > 0.5) {
+					var vs_int = getprop("/systems/pressurization/vs-norm");
+					if (vs_int == nil) vs_int = vs_cmd;
+					step = vs_int * dt / 60;
 				newalt = cabinalt + step;
 				if ((cabinalt < targetalt and newalt > targetalt) or (cabinalt > targetalt and newalt < targetalt)) {
 					newalt = targetalt;
 				}
+					if (newalt > aircraft_alt) newalt = aircraft_alt; # avoid negative delta-P near landing
+					setprop("/systems/pressurization/cabinalt", newalt);
+				}
+			} else if (!auto and !pause) {
+				step = manvs * dt / 60;
+				newalt = cabinalt + step;
 				if (newalt > aircraft_alt) newalt = aircraft_alt; # avoid negative delta-P near landing
 				setprop("/systems/pressurization/cabinalt", newalt);
 			}
-		} else if (!auto and !pause) {
-			step = manvs * dt / 60;
-			setprop("/systems/pressurization/cabinalt", cabinalt + step);
-		}
 		
 		#if (ditch and auto) {
 			#setprop("/systems/pressurization/outflowpos", "1");

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -207,13 +207,13 @@ var PNEU = {
 		if (vs_cmd == nil) vs_cmd = targetvs;
 		var dt = getprop("/sim/time/delta-sec");
 		if (dt == nil) dt = 0.1;
-		var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft");
-		if (aircraft_alt == nil) aircraft_alt = cabinalt;
-		var aircraft_vs = getprop("/velocities/vertical-speed-fps");
-		if (aircraft_vs == nil) aircraft_vs = 0;
-		aircraft_vs *= 60; # fpm
-		var landing_elev = getprop("/systems/pressurization/landing-elev");
-		if (landing_elev == nil) landing_elev = aircraft_alt;
+			var aircraft_alt = getprop("/instrumentation/altimeter/indicated-altitude-ft");
+			if (aircraft_alt == nil) aircraft_alt = cabinalt;
+			var aircraft_vs = getprop("/velocities/vertical-speed-fps");
+			if (aircraft_vs == nil) aircraft_vs = 0;
+			aircraft_vs *= 60; # fpm
+			var landing_elev = getprop("/systems/pressurization/landing-elev");
+			if (landing_elev == nil) landing_elev = aircraft_alt;
 		var step = 0;
 		var newalt = cabinalt;
 		if (dt < 0.01) dt = 0.01;
@@ -227,6 +227,7 @@ var PNEU = {
 		if (targetalt == nil) targetalt = cabinalt;
 		
 		setprop("/systems/pressurization/diff-to-target", targetalt - cabinalt); 
+		setprop("/systems/pressurization/diff-to-targetalt", targetalt - cabinalt); 
 		setprop("/systems/pressurization/deltap", cabinpsi - ambient); 
 	
 		if ((pressmode == "GN") and (pressmode != "CL") and (wowl and wowr) and ((state1 == "MCT") or (state1 == "TOGA")) and ((state2 == "MCT") or (state2 == "TOGA"))) {
@@ -235,27 +236,36 @@ var PNEU = {
 			setprop("/systems/pressurization/mode", "CL");	
 		}
 		
+		# latch landing elevation: on ground track current altitude, in air prefer FMGC value if sane
+		var ldg_prop = getprop("/FMGC/internal/ldg-elev");
+		if (wowl and wowr) {
+			landing_elev = aircraft_alt;
+			setprop("/systems/pressurization/landing-elev", landing_elev);
+		} else if (ldg_prop != nil and ldg_prop > -1500 and ldg_prop < 20000) {
+			landing_elev = ldg_prop;
+			setprop("/systems/pressurization/landing-elev", landing_elev);
+		}
+		
 		var diff = targetalt - cabinalt;
 		var commanded_vs = targetvs; # default to schedule
 		if (auto and !pause and !wowl and !wowr) {
-			# latch landing elevation: on ground track current altitude, in air prefer FMGC value if sane
-			var ldg_prop = getprop("/FMGC/internal/ldg-elev");
-			if (wowl and wowr) {
-				landing_elev = aircraft_alt;
-				setprop("/systems/pressurization/landing-elev", landing_elev);
-			} else if (ldg_prop != nil and ldg_prop > -1500 and ldg_prop < 20000) {
-				landing_elev = ldg_prop;
-				setprop("/systems/pressurization/landing-elev", landing_elev);
-			}
-			
 			var alt_above_ldg = aircraft_alt - landing_elev;
 			if (alt_above_ldg < 0) alt_above_ldg = 0;
-			var vs_for_time = math.max(math.abs(aircraft_vs), 50); # avoid divide-by-zero
-			var time_to_ldg = alt_above_ldg / vs_for_time; # minutes? (ft / fpm)
-			if (time_to_ldg < 0.01) time_to_ldg = 0.01; # protect
-			var catchup_rate = diff / time_to_ldg; # ft/min target to close by landing
-			if (catchup_rate > 1500) catchup_rate = 1500;
-			if (catchup_rate < -1500) catchup_rate = -1500;
+			var vs_floor = 750; # fpm for time metric
+			var vs_for_time = math.max(math.abs(aircraft_vs), vs_floor);
+			var t_go = alt_above_ldg / vs_for_time; # minutes (ft / fpm)
+			var VsMax = 1500; # fpm clamp
+			var t_need = math.abs(diff) / VsMax;
+			var t_min = math.max(dt / 60, 0.02); # minutes
+			t_go = math.max(t_go, t_min);
+			t_need = math.max(t_need, t_min);
+			var t_eff = math.sqrt(t_go * t_need);
+			var catchup_rate = 0;
+			if (math.abs(diff) > 25) {
+				catchup_rate = diff / t_eff;
+				if (catchup_rate > VsMax) catchup_rate = VsMax;
+				if (catchup_rate < -VsMax) catchup_rate = -VsMax;
+			}
 			commanded_vs = targetvs + catchup_rate;
 		} else if (!auto and !pause) {
 			commanded_vs = manvs;

--- a/Nasal/Systems/pneumatics.nas
+++ b/Nasal/Systems/pneumatics.nas
@@ -281,6 +281,7 @@ var PNEU = {
 		if (p_static != nil) ambient_calc = p_static * 0.491154;
 		ambient = ambient_calc;
 		if (ambient == nil) ambient = ambient_prev;
+		if (ambient == nil) ambient = 14.7;
 		setprop("/systems/pressurization/ambientpsi", ambient);
 		if (cabinpsi == nil) cabinpsi = ambient;
 		if (cabinalt == nil) {

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -315,21 +315,16 @@
 		<input>
 			<condition>
 				<equals>
-					<property>/gear/gear[1]/wow</property>
+					<property>/systems/pressurization/eq-mode</property>
 					<value>1</value>
 				</equals>
 			</condition>
-			<expression>
-				<min>
-					<property>/systems/pressurization/landing-elev</property>
-					<property>/instrumentation/altimeter/pressure-alt-ft</property>
-				</min>
-			</expression>
+			<property>/systems/pressurization/eq-targetalt</property>
 		</input>
 		<input>
 			<condition>
 				<not>
-					<property>/gear/gear[1]/wow</property>
+					<property>/systems/pressurization/eq-mode</property>
 					<value>1</value>
 				</not>
 			</condition>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -425,7 +425,7 @@
 				</table>
 			</expression>
 		</input>
-		<output>/systems/pressurization/ambientpsi-isa</output>
+		<output>/systems/pressurization/ambientpsi</output>
 	</filter>
 
 	<filter>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -519,7 +519,7 @@
 				</max>
 			</expression>
 		</input>
-		<output>/systems/pressurization/landing-elev</output>
+		<output>/systems/pressurization/landing-elev-raw</output>
 	</filter>
 	
 	<filter>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -529,16 +529,18 @@
 		<update-interval-secs>0.05</update-interval-secs>
 		<input>
 			<expression>
-				<table>
-					<property>/it-autoflight/internal/vert-speed-fpm</property>
-					<entry><ind>-50000</ind><dep> -750</dep></entry>
-					<entry><ind> -2000</ind><dep> -750</dep></entry>
-					<entry><ind> -1000</ind><dep> -350</dep></entry>
-					<entry><ind>     0</ind><dep>    0</dep></entry>
-					<entry><ind>  1000</ind><dep>  250</dep></entry>
-					<entry><ind>  2000</ind><dep>  450</dep></entry>
-					<entry><ind>  3000</ind><dep>  600</dep></entry>
-					<entry><ind>  4000</ind><dep>  750</dep></entry>
+					<table>
+						<property>/it-autoflight/internal/vert-speed-fpm</property>
+						<entry><ind>-50000</ind><dep> -750</dep></entry>
+						<entry><ind> -4000</ind><dep> -750</dep></entry>
+						<entry><ind> -3000</ind><dep> -600</dep></entry>
+						<entry><ind> -2000</ind><dep> -500</dep></entry>
+						<entry><ind> -1000</ind><dep> -250</dep></entry>
+						<entry><ind>     0</ind><dep>    0</dep></entry>
+						<entry><ind>  1000</ind><dep>  250</dep></entry>
+						<entry><ind>  2000</ind><dep>  450</dep></entry>
+						<entry><ind>  3000</ind><dep>  600</dep></entry>
+						<entry><ind>  4000</ind><dep>  750</dep></entry>
 					<entry><ind>  5000</ind><dep>  750</dep></entry>
 					<entry><ind> 10000</ind><dep>  750</dep></entry>
 					<entry><ind> 50000</ind><dep>  750</dep></entry>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -398,7 +398,7 @@
 		<input>
 			<expression>
 				<table>
-					<property>/instrumentation/altimeter/indicated-altitude-ft</property>
+					<property>/instrumentation/altimeter/pressure-alt-ft</property>
 					<entry><ind>-1000</ind><dep>16.50000</dep></entry>
 					<entry><ind>    0</ind><dep>14.70000</dep></entry>
 					<entry><ind> 1000</ind><dep>14.20000</dep></entry>
@@ -437,7 +437,7 @@
 				</table>
 			</expression>
 		</input>
-		<output>/systems/pressurization/ambientpsi</output>
+		<output>/systems/pressurization/ambientpsi-isa</output>
 	</filter>
 
 	<filter>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -352,7 +352,6 @@
 					<property>/systems/pressurization/cabinalt-norm</property>
 					<entry><ind>-1000</ind><dep>16.50000</dep></entry>
 					<entry><ind>    0</ind><dep>14.70000</dep></entry>
-					<entry><ind>    0</ind><dep>14.70000</dep></entry>
 					<entry><ind> 1000</ind><dep>14.20000</dep></entry>
 					<entry><ind> 2000</ind><dep>13.60000</dep></entry>
 					<entry><ind> 3000</ind><dep>13.20000</dep></entry>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -299,7 +299,7 @@
 					<entry><ind> 5000</ind><dep>1100</dep></entry>
 					<entry><ind>20000</ind><dep>5200</dep></entry>
 					<entry><ind>30000</ind><dep>6700</dep></entry>
-					<entry><ind>30000</ind><dep>7900</dep></entry>
+						<entry><ind>35000</ind><dep>7900</dep></entry>
 					<entry><ind>40500</ind><dep>8000</dep></entry>
 				</table>
 			</expression>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -292,18 +292,18 @@
 		<update-interval-secs>0.1</update-interval-secs>
 		<input>
 			<expression>
-				<table>
-					<property>/instrumentation/altimeter/indicated-altitude-ft</property>
-					<entry><ind>    0</ind><dep>   0</dep></entry>
-					<entry><ind> 1000</ind><dep> 500</dep></entry>
-					<entry><ind> 5000</ind><dep>1100</dep></entry>
-					<entry><ind>20000</ind><dep>5200</dep></entry>
-					<entry><ind>30000</ind><dep>6700</dep></entry>
+					<table>
+						<property>/instrumentation/altimeter/indicated-altitude-ft</property>
+						<entry><ind>    0</ind><dep>   0</dep></entry>
+						<entry><ind> 1000</ind><dep> 500</dep></entry>
+						<entry><ind> 5000</ind><dep>1100</dep></entry>
+						<entry><ind>20000</ind><dep>4900</dep></entry>
+						<entry><ind>30000</ind><dep>6900</dep></entry>
 						<entry><ind>35000</ind><dep>7900</dep></entry>
-					<entry><ind>40500</ind><dep>8000</dep></entry>
-				</table>
-			</expression>
-		</input>
+						<entry><ind>40500</ind><dep>8000</dep></entry>
+					</table>
+				</expression>
+			</input>
 		<output>/systems/pressurization/targetalt-cmd</output>
 	</filter>
 	

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -319,7 +319,12 @@
 					<value>1</value>
 				</equals>
 			</condition>
-			<property>/systems/pressurization/cabinalt-norm</property>
+			<expression>
+				<min>
+					<property>/systems/pressurization/landing-elev</property>
+					<property>/instrumentation/altimeter/pressure-alt-ft</property>
+				</min>
+			</expression>
 		</input>
 		<input>
 			<condition>
@@ -329,10 +334,13 @@
 				</not>
 			</condition>
 			<expression>
-				<max>
-					<property>/systems/pressurization/targetalt-cmd</property>
-					<property>/systems/pressurization/landing-elev</property>
-				</max>
+				<min>
+					<property>/instrumentation/altimeter/pressure-alt-ft</property>
+					<max>
+						<property>/systems/pressurization/targetalt-cmd</property>
+						<property>/systems/pressurization/landing-elev</property>
+					</max>
+				</min>
 			</expression>
 		</input>
 		<output>/systems/pressurization/targetalt</output>
@@ -370,21 +378,6 @@
 		<gain>1.0</gain>
 		<update-interval-secs>0.1</update-interval-secs>
 		<input>
-			<condition>
-				<equals>
-					<property>/gear/gear[1]/wow</property>
-					<value>1</value>
-				</equals>
-			</condition>
-			<property>/systems/pressurization/ambientpsi</property>
-		</input>
-		<input>
-			<condition>
-				<not>
-					<property>/gear/gear[1]/wow</property>
-					<value>1</value>
-				</not>
-			</condition>
 			<property>/systems/pressurization/cabinpsi-target</property>
 		</input>
 		<output>/systems/pressurization/cabinpsi</output>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -314,16 +314,10 @@
 		<update-interval-secs>0.1</update-interval-secs>
 		<input>
 			<condition>
-				<or>
-					<equals>
-						<property>/gear/gear[1]/wow</property>
-						<value>1</value>
-					</equals>
-					<less-than>
-						<property>/systems/pressurization/targetalt-cmd</property>
-						<property>/systems/pressurization/cabinalt-norm</property>
-					</less-than>
-				</or>
+				<equals>
+					<property>/gear/gear[1]/wow</property>
+					<value>1</value>
+				</equals>
 			</condition>
 			<property>/systems/pressurization/cabinalt-norm</property>
 		</input>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -533,15 +533,15 @@
 					<property>/it-autoflight/internal/vert-speed-fpm</property>
 					<entry><ind>-50000</ind><dep> -750</dep></entry>
 					<entry><ind> -2000</ind><dep> -750</dep></entry>
-					<entry><ind> -1000</ind><dep> -250</dep></entry>
+					<entry><ind> -1000</ind><dep> -350</dep></entry>
 					<entry><ind>     0</ind><dep>    0</dep></entry>
-					<entry><ind>  1000</ind><dep>  810</dep></entry>
-					<entry><ind>  2000</ind><dep> 1640</dep></entry>
-					<entry><ind>  3000</ind><dep> 2100</dep></entry>
-					<entry><ind>  4000</ind><dep> 2440</dep></entry>
-					<entry><ind>  5000</ind><dep> 3000</dep></entry>
-					<entry><ind> 10000</ind><dep> 5000</dep></entry>
-					<entry><ind> 50000</ind><dep>50000</dep></entry>
+					<entry><ind>  1000</ind><dep>  250</dep></entry>
+					<entry><ind>  2000</ind><dep>  450</dep></entry>
+					<entry><ind>  3000</ind><dep>  600</dep></entry>
+					<entry><ind>  4000</ind><dep>  750</dep></entry>
+					<entry><ind>  5000</ind><dep>  750</dep></entry>
+					<entry><ind> 10000</ind><dep>  750</dep></entry>
+					<entry><ind> 50000</ind><dep>  750</dep></entry>
 				</table>
 			</expression>
 		</input>
@@ -557,9 +557,9 @@
 			<expression>
 				<table>
 					<property>/systems/pressurization/outflowpos-man</property>
-					<entry><ind>0.0</ind><dep>-1000</dep></entry>
+					<entry><ind>0.0</ind><dep> -750</dep></entry>
 					<entry><ind>0.5</ind><dep>    0</dep></entry>
-					<entry><ind>1.0</ind><dep> 2500</dep></entry>
+					<entry><ind>1.0</ind><dep>  750</dep></entry>
 				</table>
 			</expression>
 		</input>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -293,7 +293,7 @@
 		<input>
 			<expression>
 					<table>
-						<property>/instrumentation/altimeter/indicated-altitude-ft</property>
+							<property>/instrumentation/altimeter/pressure-alt-ft</property>
 						<entry><ind>    0</ind><dep>   0</dep></entry>
 						<entry><ind> 1000</ind><dep> 500</dep></entry>
 						<entry><ind> 5000</ind><dep>1100</dep></entry>

--- a/Systems/libraries.xml
+++ b/Systems/libraries.xml
@@ -328,7 +328,12 @@
 					<value>1</value>
 				</not>
 			</condition>
-			<property>/systems/pressurization/targetalt-cmd</property>
+			<expression>
+				<max>
+					<property>/systems/pressurization/targetalt-cmd</property>
+					<property>/systems/pressurization/landing-elev</property>
+				</max>
+			</expression>
 		</input>
 		<output>/systems/pressurization/targetalt</output>
 	</filter>
@@ -499,6 +504,22 @@
 		</input>
 		<output>/systems/pressurization/cabinalt-norm</output>
 		<max-rate-of-change>40500</max-rate-of-change>
+	</filter>
+
+	<filter>
+		<name>Pressurization Landing Elevation</name>
+		<type>gain</type>
+		<gain>1.0</gain>
+		<update-interval-secs>0.1</update-interval-secs>
+		<input>
+			<expression>
+				<max>
+					<property>/FMGC/internal/ldg-elev</property>
+					<property>/position/ground-elev-ft</property>
+				</max>
+			</expression>
+		</input>
+		<output>/systems/pressurization/landing-elev</output>
 	</filter>
 	
 	<filter>


### PR DESCRIPTION
### Tato větev je nosnou / base větví pro další PR v rámci systému tlakování
* base branch: [kchodl/dev](https://github.com/kchodl/A320-family/tree/kchodl/dev)
* [another PRs to kchodl/dev](https://github.com/kchodl/A320-family/pulls?q=is%3Aopen+base%3Akchodl%2Fdev+)

------

## TL;DR
This PR hardens the A320-family cabin pressurization model so it behaves robustly across the full flight (climb/cruise/descent) and on-ground equalization:
- **Fixes descent “freeze”** by ensuring the cabin target schedule continues to follow aircraft altitude while airborne.
- Uses a **BARO-independent altitude** (pressure altitude) for schedule/guards to avoid false transients from pilot QNH/BARO knob changes.
- Adds **ground equalization** (eq-mode) so the cabin naturally equalizes on the ground (even without packs), instead of masking warnings.
- Makes the integrator **dt-aware and clamped**, with explicit **rate limits** and **underpressure guard** to prevent pathological behavior.
- Adds a **ground bootstrap** to avoid startup “do-what-I-mean” drift while FG/JSBSim altitudes settle.
- Ensures key pressurization properties are written as **numeric types** (not numeric strings) to support external real-time graphing (Phy).

---

## Context / Problem statement
The legacy pressurization model exhibited multiple edge-case failures that were easy to trigger in normal sim usage:
- During **descent**, the cabin target altitude could effectively **freeze**, preventing the cabin from reducing altitude as the aircraft descended.
- Changes to **BARO/QNH** could introduce **false pressurization transients**, because some parts of the logic were effectively coupled to indicated altitude.
- On the ground, cabin equalization behavior was not modeled explicitly (leading to “masking” temptations).
- Startup conditions could produce extended “catch-up” behavior because **pressure altitude takes a few seconds to stabilize**.
- For tooling: some numeric pressurization properties were stored as **strings**, which FlightGear tolerates, but **external graphing (Phy)** rejects.

---

## Goals
1. Keep the model **low-invasive** and consistent with existing architecture:
   - Altitude schedule via table (“targetalt-cmd”),
   - Catch-up term,
   - dt-based integrator,
   - VS chain (`vs` → `vs-norm`).
2. Make behavior **deterministic and safe**:
   - Explicit dt clamping,
   - Hard VS clamp (never exceeding the established ±750 fpm safety envelope),
   - Underpressure guard.
3. Decouple critical parts from pilot BARO knob:
   - Use **pressure altitude** for schedule input and guards.
4. Model **ground equalization** explicitly (instead of gating warnings).
5. Provide **review-friendly instrumentation** via properties and logs.
6. Ensure properties required by tooling are written as **numeric types**.

---

## High-level approach
### Variant B: BARO-independent where it matters
The PR separates altitude concepts and uses them intentionally:
- **`alt_ind`**: indicated altitude (MSL-like). Useful for ground reference / landing elevation latch.
- **`alt_press`**: pressure altitude (BARO-independent). Used for:
  - Schedule input (`targetalt-cmd`),
  - Airborne target selection logic,
  - Underpressure guard,
  - Ground equalization target.

This avoids BARO knob changes “moving the goalposts” for pressurization.

### Ground equalization (eq-mode)
Instead of “hiding” cabin delta-P warnings by gating logic, we model an explicit **equalization mode** on ground:
- When on ground, **eq-mode** drives target altitude from **eq-targetalt** (derived primarily from pressure altitude).
- The cabin VS command becomes a controlled equalization rate toward that target.
- The integrator remains active on ground even without packs (with safety clamps intact).

### Bootstrap to avoid startup drift
On startup, FG/JSBSim altitude properties may settle for several seconds. The PR adds a ground-only bootstrap that:
- Waits for a **valid** pressure altitude and a short **stability window**,
- Requires low groundspeed,
- Then “snaps” cabin/target once to the ground equalization reference,
- And exports debug properties so behavior is observable.

---

## Algorithm & behavior (core logic)
### Inputs / signals
Key property inputs include:
- `/instrumentation/altimeter/indicated-altitude-ft` (alt_ind)
- `/instrumentation/altimeter/pressure-alt-ft` (alt_press)
- WOW (on-ground detection)
- Doors (open/closed)
- Pack factor / press availability signals
- Landing elevation (latched)
- Target schedule output: `/systems/pressurization/targetalt-cmd`

### Target altitude selection
**Airborne (normal logic):**
- `targetalt` is derived from the schedule and constrained:
  - Schedule output is produced from a table keyed by **pressure altitude** (`targetalt-cmd`).
  - A landing-elevation floor is applied (avoid commanding below a sane ground reference).
  - A final “aircraft altitude cap” uses **pressure altitude**, preventing inconsistent ambient/cabin pressure states.

**On-ground (eq-mode override):**
- `targetalt` is overridden by `eq-targetalt` while `eq-mode == 1`.
- This provides an explicit, predictable equalization target on the ground.

### State logic / transitions
- `eq-mode` is enabled on ground (pause-safe).
- Press availability is latched from pack factor, but on-ground logic keeps behavior predictable (no “stuck press-avail=1” at sim start).
- Landing elevation is latched:
  - On ground: track ground reference.
  - In air: prefer FMGC landing elevation when it is sane.

### Integration / filtering approach
- Cabin altitude integration is **dt-based** (time-step aware), with dt clamped to a safe operating range:
  - Avoids dependence on a fixed “10 Hz loop” assumption.
  - Prevents overshoot and instability when frame rate or sim time-step varies.
- A catch-up term is applied when the cabin-target difference is significant, but always within limits.

### Limits / thresholds / clamps
The model includes explicit safety envelopes and stability thresholds:
- **Cabin VS hard clamp** stays within the established ±750 fpm envelope.
- Equalization VS has its own tighter clamp to avoid harsh behavior on ground.
- dt is clamped to prevent both numerical blow-up and ineffective integration steps.
- Bootstrap stability uses:
  - Validity checks for pressure altitude range,
  - Stability window accumulation,
  - Anchor drift guard,
  - Low groundspeed requirement,
  - A timeout to avoid permanent waiting.

### Fallbacks / failsafes
- **Nil-safe defaults** for missing properties.
- **Underpressure guard:** cabin altitude integration is capped such that `cabinalt <= alt_press` to avoid negative delta-P spikes near landing.
- Bootstrap has a hard timeout and exports its own status flags for diagnosis.

---

## Implementation notes (by file)
### `Systems/libraries.xml`
- Cabin schedule (`/systems/pressurization/targetalt-cmd`) is computed from a **table keyed by pressure altitude**.
- `Target Pressurize Altitude` selects between:
  - **eq-mode override** (`eq-targetalt`) when on ground,
  - Normal airborne logic otherwise, including landing elevation floor and a pressure-altitude cap.

### `Nasal/Systems/pneumatics.nas`
- Implements:
  - Press availability latch,
  - eq-mode state and equalization VS,
  - dt clamping,
  - Catch-up and integration steps,
  - Underpressure guard,
  - Bootstrap (ground-only, stability-based),
  - Debug exports (bootstrap status, dt-used, etc.).
- Synchronization fix: when bootstrap “fires” and cabin altitude snaps, `cabinalt-norm` is set in the same tick (avoids a one-sample delta-P spike due to downstream tabular pressure computations lagging by a frame).

### `Nasal/FMGC/FMGC.nas`
- `reset_FMGC()` also initializes pressurization properties. This PR ensures the reset path does not reintroduce problematic types (see “Property typing” below).

---

## Property typing (tooling compatibility)
FlightGear generally tolerates numeric strings in the property tree, but external tooling may not.
This PR ensures key pressurization properties are written as **numeric literals** (not `"0"` / `"0.5"` strings):
- In the pressurization initializer (`pneumatics.nas`)
- In the FMGC reset path (`reset_FMGC()`), which can be triggered via MCDU flows and would otherwise revert types during runtime

This is intentionally a **type-correctness** change only (no functional logic change intended).

---

## Testing & verification
### Repro steps
1. Cold & dark start at an airport.
2. Observe initial stabilization:
   - Bootstrap should wait until pressure altitude stabilizes (ground + low groundspeed), then snap cabin/target once.
3. Take off and climb:
   - `targetalt-cmd` and `targetalt` should evolve with aircraft altitude.
4. Cruise then descend:
   - Cabin should **reduce altitude** in descent; target should not freeze.
5. Land and taxi:
   - `eq-mode` should drive target to `eq-targetalt` and cabin should equalize smoothly.
6. Optional: toggle packs / doors to observe expected effects (without breaking invariants).

### Evidence signals to log / inspect
Recommended properties:
- `/systems/pressurization/cabinalt`
- `/systems/pressurization/targetalt`
- `/systems/pressurization/targetalt-cmd`
- `/systems/pressurization/vs` and `/systems/pressurization/vs-norm`
- `/systems/pressurization/deltap` and `/systems/pressurization/deltap-norm`
- `/systems/pressurization/eq-mode`, `/systems/pressurization/eq-targetalt`
- `/systems/pressurization/press-avail`, `/systems/pressurization/doors-open`
- `/systems/pressurization/dt-used`
- Bootstrap debug:
  - `/systems/pressurization/cabinalt-bootstrap-done`
  - `/systems/pressurization/cabinalt-bootstrap-fire-elapsed`
  - `/systems/pressurization/cabinalt-bootstrap-stable-s`
  - `/systems/pressurization/cabinalt-bootstrap-expired`

### Invariants to watch
- `cabinalt <= alt_press` (underpressure guard)
- `abs(vs)` and `abs(vs-norm)` stay within the VS safety envelope
- In descent: `targetalt` and schedule remain responsive (no freeze)
- On ground: `eq-mode == 1` and cabin converges toward `eq-targetalt`

---

## Reviewer guide
Suggested reading order:
1. **`Systems/libraries.xml`**
   - `targetalt-cmd` schedule table (pressure-alt keyed)
   - `Target Pressurize Altitude` selector (eq-mode override + landing floor)
2. **`Nasal/Systems/pneumatics.nas`**
   - dt clamping and `dt-used`
   - `press-avail` latch logic
   - eq-mode equalization VS clamp
   - catch-up + integration step + underpressure guard
   - bootstrap block and its exported flags
3. **`Nasal/FMGC/FMGC.nas`**
   - `reset_FMGC()` pressurization initialization (type-correct numeric literals)

What to focus on in review:
- No regressions in safety clamps (VS/dt/guards).
- Airborne target computation remains consistent and BARO-independent where intended.
- Ground equalization is explicit and bounded.
- Bootstrap is one-shot, ground-only, and observable via debug properties.
- Property typing changes are minimal and do not affect runtime behavior except for tooling compatibility.

---

## Known limitations / notes
- Pressure altitude can be negative at very high QNH; this can yield negative “equalized” cabin altitude on ground. This is a **definition/altimetry artifact** (MSL vs pressure altitude) rather than a physical model failure.
- The model prioritizes robustness and determinism over high-fidelity pneumatic dynamics; it remains an altitude-based pressurization controller with bounded rates.

---

## Backward compatibility / risk assessment
- The changes are designed to be low-risk:
  - No broad refactors,
  - No changes to established safety envelopes,
  - Nil-safe defaults maintained.
- Property typing adjustments (numeric strings → numeric values) should be safe for FlightGear and improve compatibility with external tooling.