### PR TITLE
ELEC: avoid EXT->APU brownout by relaxing APU GLC EXT interlock

### DIFF
--- a/Systems/a320-electrical.xml
+++ b/Systems/a320-electrical.xml
@@ -1164,7 +1164,10 @@
 				/systems/electrical/sources/apu/output-volt le 130
 				/systems/electrical/sources/apu/output-hertz ge 361
 				/systems/electrical/sources/apu/output-hertz le 435
-				/systems/electrical/relay/ext-epc/contact-pos eq 0
+				<test logic="OR">
+					/systems/electrical/relay/ext-epc/contact-pos eq 0
+					/controls/electrical/switches/ext-pwr eq 0
+				</test>
 				/systems/electrical/sources/apu/gcu-fault ne 1 <!-- software trip -->
 			</test>
 		</switch>


### PR DESCRIPTION
### Motivation
- A transient brownout occurred during EXT->APU transfer because the APU GLC was inhibited by `/systems/electrical/relay/ext-epc/contact-pos eq 0` and the evaluated EXT contactor state could briefly remain stale. 
- The goal is to allow the APU GLC to close immediately when the pilot commands EXT off via the `ext-pwr` switch while preserving the interlock when EXT is actually present. 

### Description
- Updated `Systems/a320-electrical.xml` to relax the APU GLC EXT interlock by replacing the single test `/systems/electrical/relay/ext-epc/contact-pos eq 0` with a nested OR block. 
- Inserted a `<test logic="OR">` containing `/systems/electrical/relay/ext-epc/contact-pos eq 0` and `/controls/electrical/switches/ext-pwr eq 0` and preserved the surrounding indentation and block structure exactly. 
- No other lines, formatting, symbol names, or files were modified. 

### Testing
- Ran `git diff -- Systems/a320-electrical.xml` and confirmed the change is one deletion and three insertions in that file. 
- Ran `git status --porcelain` before and after committing and observed the single modified file as expected (post-commit output empty). 
- Created the commit with message `ELEC: avoid EXT->APU brownout by relaxing APU GLC EXT interlock`, which completed successfully (`1 file changed, 4 insertions(+), 1 deletion(-)`).
- No automated unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dafe249c8832cbbfa96951beb84af)