### PR TITLE
INTERNAL --- Fix rate_limit sense typo in misc transient timers

### DIFF
--- a/Systems/a320-misc.xml
+++ b/Systems/a320-misc.xml
@@ -533,7 +533,7 @@
 		<actuator name="/instrumentation/iesi/power/power-transient-timer">
 			<input>/instrumentation/iesi/power/power-command</input>
 			<rate_limit sense="decr">5</rate_limit>
-			<rate_limit sene="incr">100</rate_limit>
+			<rate_limit sense="incr">100</rate_limit>
 		</actuator>
 		
 		<switch name="/instrumentation/iesi/power/power-on">
@@ -675,7 +675,7 @@
 		<actuator name="/instrumentation/displays/du3/power-transient-timer">
 			<input>/instrumentation/displays/du3/power-command</input>
 			<rate_limit sense="decr">5</rate_limit>
-			<rate_limit sene="incr">100</rate_limit>
+			<rate_limit sense="incr">100</rate_limit>
 		</actuator>
 		
 		<switch name="/instrumentation/displays/du3/power-on">
@@ -712,7 +712,7 @@
 		<actuator name="/instrumentation/displays/du4/power-transient-timer">
 			<input>/instrumentation/displays/du4/power-command</input>
 			<rate_limit sense="decr">5</rate_limit>
-			<rate_limit sene="incr">100</rate_limit>
+			<rate_limit sense="incr">100</rate_limit>
 		</actuator>
 		
 		<switch name="/instrumentation/displays/du4/power-on">


### PR DESCRIPTION
### INTERNAL PR — new PR created as upstream PR
- branch renamed: codex/forensically-confirm-occurrences-of-sene= ---> **[fix/a320-misc-rate-limit-sense-typo](https://github.com/kchodl/A320-family/tree/fix/a320-misc-rate-limit-sense-typo)**
- template PR in my fork #26
- upstream PR #380
---

### Motivation
- Fix a typo in three `rate_limit` attributes where `sene="incr"` was used instead of `sense="incr"` in transient timers.
- Ensure these transient timers use the same canonical `rate_limit sense="incr|decr"` style as the rest of the file.
- Keep the change minimal and local to only the three incorrect attribute occurrences.

### Description
- Replaced `sene="incr"` with `sense="incr"` in `Systems/a320-misc.xml` for the actuators `/instrumentation/iesi/power/power-transient-timer`, `/instrumentation/displays/du3/power-transient-timer`, and `/instrumentation/displays/du4/power-transient-timer`.
- No other lines, whitespace, formatting, or files were modified.
- The replacement preserves the exact style used by existing `rate_limit` entries elsewhere in the file.

### Testing
- Ran `rg -n --no-heading 'sene="incr"' Systems/a320-misc.xml` prior to the edit and observed 3 matches as expected.
- After the edit ran `rg -n --no-heading 'sene="incr"' Systems/a320-misc.xml` and confirmed 0 matches remaining.
- Verified with a file diff that only the three attribute occurrences were changed and no other content was altered.
- Confirmed no other files were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd4fa1130832cbf7a654ba7c2518c)