### PR TITLE
Fix ENG2 BLEED HP valve connection visibility wiring

### DIFF
--- a/Models/Instruments/Lower-ECAM/Lower-ECAM-bleed.nas
+++ b/Models/Instruments/Lower-ECAM/Lower-ECAM-bleed.nas
@@ -141,11 +141,11 @@ var canvas_lowerECAMPageBleed =
 			}),
 			props.UpdateManager.FromHashValue("BleedHPValve2Cmd", 1, func(val) {
 				if (val) {
-					obj["BLEED-HP-Valve-1"].setRotation(90 * D2R);
-					obj["BLEED-HP-1-connection"].show();
+					obj["BLEED-HP-Valve-2"].setRotation(90 * D2R);
+					obj["BLEED-HP-2-connection"].show();
 				} else {
-					obj["BLEED-HP-Valve-1"].setRotation(0);
-					obj["BLEED-HP-1-connection"].hide();
+					obj["BLEED-HP-Valve-2"].setRotation(0);
+					obj["BLEED-HP-2-connection"].hide();
 				}
 			}),
 			props.UpdateManager.FromHashValue("bleedHPValve1PositionMatch", 1, func(val) {


### PR DESCRIPTION
### Motivation
- The `BleedHPValve2Cmd` handler was wired to ENG1 SVG IDs causing the ENG2 HP connection segment to remain visible even when ENG2 HP valve command is OFF.
- This caused ENG2 valve rotation and connection visibility to reflect ENG1 elements instead of ENG2.

### Description
- In `Models/Instruments/Lower-ECAM/Lower-ECAM-bleed.nas` inside `props.UpdateManager.FromHashValue("BleedHPValve2Cmd", 1, func(val) { ... })` the SVG references were corrected to ENG2 IDs.
- Replaced `obj["BLEED-HP-Valve-1"]` with `obj["BLEED-HP-Valve-2"]` in both branches and `obj["BLEED-HP-1-connection"]` with `obj["BLEED-HP-2-connection"]` in both branches, preserving the `show()` on `val` true and `hide()` on `val` false semantics.
- The change is minimal and deterministic: 4 deletions and 4 insertions limited to the single callback.

### Testing
- Ran `rg -n "BleedHPValve2Cmd"` to locate the handler and confirm the single change point, which succeeded.
- Ran `git diff -- Models/Instruments/Lower-ECAM/Lower-ECAM-bleed.nas` to validate the hunk was limited to the intended ID substitutions, which succeeded.
- Committed the change with `git commit -am "Fix ENG2 BLEED HP valve connection visibility wiring"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e82cfc8d0832c85ab9e7523e238dc)