### PR TITLE
Increase PRV not-shut APU debounce to 2s

### DIFF
--- a/Systems/a320-fwc.xml
+++ b/Systems/a320-fwc.xml
@@ -75,13 +75,13 @@
 		<actuator name="/ECAM/warnings/timer/prv-1-not-shut-apu-output">
 			<input>/ECAM/warnings/logic/prv-1-not-shut-apu</input>
 			<rate_limit sense="decr">120</rate_limit> <!-- Instant -->
-			<rate_limit sense="incr">1</rate_limit> <!-- 1 second -->
+			<rate_limit sense="incr">0.5</rate_limit> <!-- 2 seconds -->
 		</actuator>
 		
 		<actuator name="/ECAM/warnings/timer/prv-2-not-shut-apu-output">
 			<input>/ECAM/warnings/logic/prv-2-not-shut-apu</input>
 			<rate_limit sense="decr">120</rate_limit> <!-- Instant -->
-			<rate_limit sense="incr">1</rate_limit> <!-- 1 second -->
+			<rate_limit sense="incr">0.5</rate_limit> <!-- 2 seconds -->
 		</actuator>
 		
 		<actuator name="/ECAM/warnings/timer/prv-1-not-shut-output">


### PR DESCRIPTION
### Motivation
- Short transient PRV “disagree” during APU/crossbleed transitions can trip the APU PRV “not shut” timer after 1 second and set the SR latch contributing to ENG BLEED FAULT.  
- The change aligns APU PRV debounce with the existing 2-second precedent used elsewhere.  
- Increasing the rise delay reduces false positives from brief transients without affecting fall behavior.  

### Description
- Updated two `rate_limit` rise values from `1` to `0.5` and their inline comments to `<!-- 2 seconds -->` in `Systems/a320-fwc.xml`.  
- The changes were applied only in actuators `/ECAM/warnings/timer/prv-1-not-shut-apu-output` and `/ECAM/warnings/timer/prv-2-not-shut-apu-output`.  
- No other lines, whitespace, or files were modified and non-APU PRV timers were left unchanged.  

### Testing
- Applied the patch with `apply_patch` which completed successfully.  
- Verified the working diff with `git -C /workspace/A320-family diff -- Systems/a320-fwc.xml` and confirmed the unified diff contains exactly the two intended value+comment changes.  
- Committed the change using `git -C /workspace/A320-family commit -m "Increase PRV not-shut APU debounce to 2s to avoid transient BLEED FAULT"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ede07b4e8832ca12fb38347149887)