### PR TITLE
Tighten ENG2 PRV crossbleed hysteresis thresholds

### DIFF
--- a/Systems/a320-pneumatic.xml
+++ b/Systems/a320-pneumatic.xml
@@ -329,14 +329,14 @@
 				/controls/pneumatics/switches/bleed-2 eq 0
 				<test logic="AND">
 					/systems/pneumatics/valves/apu-bleed-valve eq 1
-					<test logic="OR"> <!-- crossbleed hysteresis: closing>=0.65, opening>=0.35 -->
+					<test logic="OR"> <!-- crossbleed hysteresis: closing>=0.64, opening>=0.45 -->
 						<test logic="AND">
 							/systems/pneumatics/valves/crossbleed-valve-cmd eq 0
-							/systems/pneumatics/valves/crossbleed-valve ge 0.65
+							/systems/pneumatics/valves/crossbleed-valve ge 0.64
 						</test>
 						<test logic="AND">
 							/systems/pneumatics/valves/crossbleed-valve-cmd eq 1
-							/systems/pneumatics/valves/crossbleed-valve ge 0.35
+							/systems/pneumatics/valves/crossbleed-valve ge 0.45
 						</test>
 					</test>
 				</test>


### PR DESCRIPTION
# INACTIVE

---

### Motivation
- Reduce overlap between ENG2 PRV and crossbleed valve movements while preserving pressure safety margins.
- Make minimal numeric adjustments to the crossbleed hysteresis thresholds to tighten coordination behavior.

### Description
- Update the inline comment in `Systems/a320-pneumatic.xml` to `closing>=0.64, opening>=0.45`.
- Change `/systems/pneumatics/valves/crossbleed-valve ge 0.65` to `ge 0.64` in the `crossbleed-valve-cmd eq 0` branch.
- Change `/systems/pneumatics/valves/crossbleed-valve ge 0.35` to `ge 0.45` in the `crossbleed-valve-cmd eq 1` branch.

### Testing
- Ran the `apply_patch` update which reported success and modified `Systems/a320-pneumatic.xml`.
- Verified the changes with `git diff -- Systems/a320-pneumatic.xml` and observed only the three numeric edits.
- Committed the change with `git commit -am` which completed successfully.
- No automated unit or behavioral tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c0bebbf0832caecc77b8dca264ae)